### PR TITLE
Harden Convex and TanStack auth checks

### DIFF
--- a/apps/tanstack-start/src/lib/ai/tools/search-project.ts
+++ b/apps/tanstack-start/src/lib/ai/tools/search-project.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/silo/core.server";
 import { retrieveProjectContextForUser } from "@/server/rag/retrieve";
 
-async function resolveAttachmentUrls(attachmentIds: string[]) {
+async function resolveAttachmentUrls(userId: string, attachmentIds: string[]) {
   if (attachmentIds.length === 0) {
     return new Map<
       string,
@@ -28,6 +28,7 @@ async function resolveAttachmentUrls(attachmentIds: string[]) {
     api.functions.embeddings.internal_getAttachmentSummaries,
     {
       secret: env.INTERNAL_CONVEX_SECRET,
+      userId,
       attachmentIds,
     },
   );
@@ -170,7 +171,10 @@ export const searchProjectKnowledgeTool = (
         projectContext.modelId,
       );
 
-      const attachmentUrls = await resolveAttachmentUrls(rawAttachmentIds);
+      const attachmentUrls = await resolveAttachmentUrls(
+        projectContext.userId,
+        rawAttachmentIds,
+      );
 
       for (const attachmentId of rawAttachmentIds) {
         const attachment = attachmentUrls.get(attachmentId);

--- a/apps/tanstack-start/src/routes/api/chat/index.ts
+++ b/apps/tanstack-start/src/routes/api/chat/index.ts
@@ -361,7 +361,10 @@ export const Route = createFileRoute("/api/chat/")({
               api.functions.instructions.getEffectiveInstruction,
               { instructionId: thread?.settings.instructionId },
             );
-            const prompt = selectedInstruction?.prompt?.trim();
+            const prompt =
+              selectedInstruction === null
+                ? undefined
+                : selectedInstruction.prompt.trim();
             if (prompt) {
               selectedInstructionPrompt = prompt;
             }

--- a/apps/tanstack-start/src/routes/api/chat/index.ts
+++ b/apps/tanstack-start/src/routes/api/chat/index.ts
@@ -20,7 +20,11 @@ import { env } from "@/env";
 import { createToolRuntime } from "@/lib/ai/tools";
 import { formatProjectKnowledgeChunk } from "@/lib/ai/tools/project-knowledge-format";
 import { selectProjectMediaAttachmentIds } from "@/lib/ai/tools/project-knowledge-media";
-import { fetchAuthMutation, fetchAuthQuery } from "@/lib/auth/server";
+import {
+  fetchAuthMutation,
+  fetchAuthQuery,
+  getRequestUserIdFromHeaders,
+} from "@/lib/auth/server";
 import { buildAttachmentUrl } from "@/lib/silo/core.server";
 import { createUpstashPubSub } from "@/lib/upstash-resumable-stream";
 import { throttle } from "@/lib/utils/throttle";
@@ -275,6 +279,13 @@ export const Route = createFileRoute("/api/chat/")({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        const requestUserId = await getRequestUserIdFromHeaders(
+          request.headers,
+        );
+        if (!requestUserId) {
+          return new Response("Unauthorized", { status: 401 });
+        }
+
         const parsedBody = requestBody.parse(await request.json());
 
         const {
@@ -303,6 +314,7 @@ export const Route = createFileRoute("/api/chat/")({
           try {
             await fetchAuthMutation(api.functions.threads.internal_failStream, {
               secret: env.INTERNAL_CONVEX_SECRET,
+              userId: requestUserId,
               threadId,
               assistantMessageId,
               error: errorMessage,
@@ -376,6 +388,7 @@ export const Route = createFileRoute("/api/chat/")({
             if (queryText) {
               try {
                 const { chunks } = await retrieveProjectContext({
+                  userId: requestUserId,
                   chatProjectId,
                   query: queryText,
                   k: 6,
@@ -550,6 +563,8 @@ export const Route = createFileRoute("/api/chat/")({
                   api.functions.threads.internal_updateMessageUsage,
                   {
                     secret: env.INTERNAL_CONVEX_SECRET,
+                    userId: requestUserId,
+                    threadId,
                     messageId: assistantMessageId,
                     usage: usageData ?? {
                       promptTokens: 0,
@@ -572,6 +587,7 @@ export const Route = createFileRoute("/api/chat/")({
                   api.functions.threads.internal_checkMessageAbort,
                   {
                     secret: env.INTERNAL_CONVEX_SECRET,
+                    userId: requestUserId,
                     messageId: assistantMessageId,
                     threadId: threadId,
                   },
@@ -621,6 +637,7 @@ export const Route = createFileRoute("/api/chat/")({
                 api.functions.threads.internal_completeStream,
                 {
                   secret: env.INTERNAL_CONVEX_SECRET,
+                  userId: requestUserId,
                   threadId: threadId,
                   assistantMessageId: assistantMessageId,
                   parts,
@@ -645,6 +662,7 @@ export const Route = createFileRoute("/api/chat/")({
                 api.functions.threads.internal_setActiveStreamId,
                 {
                   secret: env.INTERNAL_CONVEX_SECRET,
+                  userId: requestUserId,
                   threadId: threadId,
                   streamId,
                   messageId: assistantMessageId,

--- a/apps/tanstack-start/src/server/rag/convex-vector-store.ts
+++ b/apps/tanstack-start/src/server/rag/convex-vector-store.ts
@@ -74,13 +74,17 @@ export class ConvexVectorStore implements VectorStore {
     }));
   }
 
-  async deleteForAttachment(attachmentId: string): Promise<void> {
+  async deleteForAttachment(input: {
+    userId: string;
+    attachmentId: string;
+  }): Promise<void> {
     const client = getInternalConvexClient();
     await client.mutation(
       api.functions.embeddings.internal_deleteEmbeddingsForAttachment,
       {
         secret: env.INTERNAL_CONVEX_SECRET,
-        attachmentId,
+        userId: input.userId,
+        attachmentId: input.attachmentId,
       },
     );
   }

--- a/apps/tanstack-start/src/server/rag/index-attachment.ts
+++ b/apps/tanstack-start/src/server/rag/index-attachment.ts
@@ -28,6 +28,7 @@ function generateEmbeddingId() {
 }
 
 async function setStatus(input: {
+  userId: string;
   attachmentId: string;
   status: "queued" | "indexing" | "indexed" | "failed";
   error?: string;
@@ -38,6 +39,7 @@ async function setStatus(input: {
     api.functions.embeddings.internal_setAttachmentEmbeddingStatus,
     {
       secret: env.INTERNAL_CONVEX_SECRET,
+      userId: input.userId,
       attachmentId: input.attachmentId,
       status: input.status,
       error: input.error,
@@ -56,7 +58,11 @@ async function setStatus(input: {
  * message recorded — the user can retry via a UI affordance.
  */
 export async function embedAndIndexProjectFile(input: IndexProjectFileInput) {
-  await setStatus({ attachmentId: input.attachmentId, status: "indexing" });
+  await setStatus({
+    userId: input.userId,
+    attachmentId: input.attachmentId,
+    status: "indexing",
+  });
 
   try {
     const downloadUrl = await buildAttachmentUrl({
@@ -85,6 +91,7 @@ export async function embedAndIndexProjectFile(input: IndexProjectFileInput) {
 
     if (extracted.length === 0) {
       await setStatus({
+        userId: input.userId,
         attachmentId: input.attachmentId,
         status: "indexed",
         chunkCount: 0,
@@ -132,6 +139,7 @@ export async function embedAndIndexProjectFile(input: IndexProjectFileInput) {
 
     if (embedded.length === 0) {
       await setStatus({
+        userId: input.userId,
         attachmentId: input.attachmentId,
         status: "indexed",
         chunkCount: 0,
@@ -147,6 +155,7 @@ export async function embedAndIndexProjectFile(input: IndexProjectFileInput) {
     });
 
     await setStatus({
+      userId: input.userId,
       attachmentId: input.attachmentId,
       status: "indexed",
       chunkCount: embedded.length,
@@ -160,6 +169,7 @@ export async function embedAndIndexProjectFile(input: IndexProjectFileInput) {
     );
     try {
       await setStatus({
+        userId: input.userId,
         attachmentId: input.attachmentId,
         status: "failed",
         error: message.slice(0, 1000),

--- a/apps/tanstack-start/src/server/rag/retrieve.ts
+++ b/apps/tanstack-start/src/server/rag/retrieve.ts
@@ -1,11 +1,9 @@
-import { api } from "@redux/backend/convex/_generated/api";
-
 import type { RetrievedChunk } from "./vector-store";
-import { fetchAuthQuery } from "@/lib/auth/server";
 import { embedTexts } from "./embed-client";
 import { getVectorStore } from "./index";
 
 export interface RetrieveProjectContextInput {
+  userId: string;
   chatProjectId: string;
   query: string;
   k?: number;
@@ -58,16 +56,8 @@ export async function retrieveProjectContextForUser(
 export async function retrieveProjectContext(
   input: RetrieveProjectContextInput,
 ): Promise<RetrieveProjectContextResult> {
-  const { userId } = await fetchAuthQuery(
-    api.functions.user.getCurrentUserId,
-    {},
-  );
-  if (!userId) {
-    return { chunks: [] };
-  }
-
   return retrieveProjectContextForUser({
-    userId,
+    userId: input.userId,
     chatProjectId: input.chatProjectId,
     query: input.query,
     k: input.k ?? DEFAULT_K,

--- a/apps/tanstack-start/src/server/rag/vector-store.ts
+++ b/apps/tanstack-start/src/server/rag/vector-store.ts
@@ -48,5 +48,8 @@ export interface VectorStore {
     k: number;
   }): Promise<RetrievedChunk[]>;
 
-  deleteForAttachment(attachmentId: string): Promise<void>;
+  deleteForAttachment(input: {
+    userId: string;
+    attachmentId: string;
+  }): Promise<void>;
 }

--- a/apps/tanstack-start/src/upload.ts
+++ b/apps/tanstack-start/src/upload.ts
@@ -7,7 +7,12 @@ import { z } from "zod";
 
 import { getModelAttachmentExpects } from "@redux/types";
 
-import { getRequestUserIdFromHeaders } from "@/lib/auth/server";
+import { api } from "@redux/backend/convex/_generated/api";
+
+import {
+  fetchAuthQuery,
+  getRequestUserIdFromHeaders,
+} from "@/lib/auth/server";
 import {
   buildAttachmentUrl,
   createUploadedAttachmentRecord,
@@ -31,6 +36,28 @@ const projectAttachmentInput = z.object({
   chatProjectId: z.string(),
 });
 
+async function requireOwnedThread(threadId: string | undefined) {
+  if (!threadId) {
+    return;
+  }
+
+  const thread = await fetchAuthQuery(api.functions.threads.getThread, {
+    threadId,
+  });
+  if (!thread) {
+    throw new Error("Thread not found");
+  }
+}
+
+async function requireOwnedProject(projectId: string) {
+  const project = await fetchAuthQuery(api.functions.projects.getProject, {
+    projectId,
+  });
+  if (!project) {
+    throw new Error("Project not found");
+  }
+}
+
 // Generic accepted types for project files. Project files are part of a
 // long-lived knowledge base, not bound to a specific model's capabilities.
 const PROJECT_ATTACHMENT_EXPECTS: SiloRouteConfigInput = [
@@ -48,6 +75,7 @@ export const fileRouter = {
       if (!userId) {
         throw new Error("Unauthorized");
       }
+      await requireOwnedThread(input.threadId);
 
       return {
         userId,
@@ -113,6 +141,7 @@ export const fileRouter = {
       if (!userId) {
         throw new Error("Unauthorized");
       }
+      await requireOwnedProject(input.chatProjectId);
 
       return {
         userId,

--- a/packages/backend/convex/functions/attachments.ts
+++ b/packages/backend/convex/functions/attachments.ts
@@ -37,6 +37,24 @@ export async function attachDraftAttachmentsToMessage(
     messageId: string;
   },
 ) {
+  const thread = await ctx.db
+    .query("threads")
+    .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId))
+    .first();
+  if (thread?.userId !== ctx.userId) {
+    throw new ConvexError("Thread not found");
+  }
+
+  const message = await ctx.db
+    .query("messages")
+    .withIndex("by_threadId_messageId", (q) =>
+      q.eq("threadId", args.threadId).eq("messageId", args.messageId),
+    )
+    .first();
+  if (!message) {
+    throw new ConvexError("Message not found");
+  }
+
   for (const attachmentId of args.attachmentIds) {
     const attachment = await ctx.db
       .query("attachments")
@@ -98,6 +116,34 @@ export const internal_createUploadedAttachment = backendMutation({
   handler: async (ctx, args) => {
     const now = Date.now();
 
+    if (args.threadId && args.chatProjectId) {
+      throw new ConvexError("Attachment cannot target both thread and project");
+    }
+
+    if (args.threadId) {
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId ?? ""))
+        .first();
+      if (thread?.userId !== args.userId) {
+        throw new ConvexError("Thread not found");
+      }
+    }
+
+    if (args.chatProjectId) {
+      const project = await ctx.db
+        .query("projects")
+        .withIndex("by_projectId", (q) =>
+          q.eq("projectId", args.chatProjectId ?? ""),
+        )
+        .first();
+      if (project?.userId !== args.userId) {
+        throw new ConvexError("Project not found");
+      }
+    } else if (args.expiresAt === undefined) {
+      throw new ConvexError("Draft attachments must expire");
+    }
+
     // Project files are uploaded directly into a project's library — they
     // never expire and skip the draft -> attached lifecycle.
     const isProjectFile = args.chatProjectId !== undefined;
@@ -112,6 +158,10 @@ export const internal_createUploadedAttachment = backendMutation({
       .first();
 
     if (existing) {
+      if (existing.userId !== args.userId) {
+        throw new ConvexError("Attachment not found");
+      }
+
       await ctx.db.patch(existing._id, {
         threadId: args.threadId,
         chatProjectId: args.chatProjectId,

--- a/packages/backend/convex/functions/embeddings.ts
+++ b/packages/backend/convex/functions/embeddings.ts
@@ -208,7 +208,7 @@ export const internal_getAttachmentSummaries = backendQuery({
         .query("attachments")
         .withIndex("by_attachmentId", (q) => q.eq("attachmentId", attachmentId))
         .first();
-      if (!a || a.userId !== args.userId) continue;
+      if (a?.userId !== args.userId) continue;
       out[attachmentId] = {
         fileName: a.fileName,
         mimeType: a.mimeType,

--- a/packages/backend/convex/functions/embeddings.ts
+++ b/packages/backend/convex/functions/embeddings.ts
@@ -1,6 +1,8 @@
-import { v } from "convex/values";
+import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
+import { ConvexError, v } from "convex/values";
 
 import { api } from "../_generated/api";
+import type { DataModel } from "../_generated/dataModel";
 import { backendEnv } from "../env";
 import { backendAction, backendMutation, backendQuery } from "./index";
 
@@ -28,6 +30,35 @@ const chunkValidator = v.object({
   embeddingDims: v.number(),
 });
 
+type BackendDbCtx =
+  | GenericMutationCtx<DataModel>
+  | GenericQueryCtx<DataModel>;
+
+async function getProjectAttachmentForOwner(
+  ctx: BackendDbCtx,
+  args: {
+    userId: string;
+    attachmentId: string;
+    chatProjectId?: string;
+  },
+) {
+  const attachment = await ctx.db
+    .query("attachments")
+    .withIndex("by_attachmentId", (q) => q.eq("attachmentId", args.attachmentId))
+    .first();
+
+  if (
+    attachment?.userId !== args.userId ||
+    !attachment.chatProjectId ||
+    (args.chatProjectId !== undefined &&
+      attachment.chatProjectId !== args.chatProjectId)
+  ) {
+    throw new ConvexError("Attachment not found");
+  }
+
+  return attachment;
+}
+
 /**
  * Inserts (or replaces) the embedding rows for a single attachment. We use
  * a delete-then-insert strategy so re-indexing is fully idempotent regardless
@@ -41,6 +72,12 @@ export const internal_upsertEmbeddings = backendMutation({
     chunks: v.array(chunkValidator),
   },
   handler: async (ctx, args) => {
+    await getProjectAttachmentForOwner(ctx, {
+      userId: args.userId,
+      attachmentId: args.attachmentId,
+      chatProjectId: args.chatProjectId,
+    });
+
     // Delete any existing embeddings for this attachment
     const existing = await ctx.db
       .query("attachmentEmbeddings")
@@ -75,8 +112,13 @@ export const internal_upsertEmbeddings = backendMutation({
 });
 
 export const internal_deleteEmbeddingsForAttachment = backendMutation({
-  args: { attachmentId: v.string() },
+  args: { userId: v.string(), attachmentId: v.string() },
   handler: async (ctx, args) => {
+    await getProjectAttachmentForOwner(ctx, {
+      userId: args.userId,
+      attachmentId: args.attachmentId,
+    });
+
     const rows = await ctx.db
       .query("attachmentEmbeddings")
       .withIndex("by_attachmentId", (q) =>
@@ -94,22 +136,17 @@ export const internal_deleteEmbeddingsForAttachment = backendMutation({
 
 export const internal_setAttachmentEmbeddingStatus = backendMutation({
   args: {
+    userId: v.string(),
     attachmentId: v.string(),
     status: embeddingStatus,
     error: v.optional(v.string()),
     chunkCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const attachment = await ctx.db
-      .query("attachments")
-      .withIndex("by_attachmentId", (q) =>
-        q.eq("attachmentId", args.attachmentId),
-      )
-      .first();
-
-    if (!attachment) {
-      return { success: false };
-    }
+    const attachment = await getProjectAttachmentForOwner(ctx, {
+      userId: args.userId,
+      attachmentId: args.attachmentId,
+    });
 
     await ctx.db.patch(attachment._id, {
       embeddingStatus: args.status,
@@ -153,7 +190,7 @@ export const internal_getEmbeddingsByIds = backendQuery({
  * for citation rendering.
  */
 export const internal_getAttachmentSummaries = backendQuery({
-  args: { attachmentIds: v.array(v.string()) },
+  args: { userId: v.string(), attachmentIds: v.array(v.string()) },
   handler: async (ctx, args) => {
     const out: Record<
       string,
@@ -171,7 +208,7 @@ export const internal_getAttachmentSummaries = backendQuery({
         .query("attachments")
         .withIndex("by_attachmentId", (q) => q.eq("attachmentId", attachmentId))
         .first();
-      if (!a) continue;
+      if (!a || a.userId !== args.userId) continue;
       out[attachmentId] = {
         fileName: a.fileName,
         mimeType: a.mimeType,
@@ -238,7 +275,7 @@ export const internal_searchEmbeddings = backendAction({
     );
     const summaries = await ctx.runQuery(
       api.functions.embeddings.internal_getAttachmentSummaries,
-      { secret: env.INTERNAL_CONVEX_SECRET, attachmentIds },
+      { secret: env.INTERNAL_CONVEX_SECRET, userId: args.userId, attachmentIds },
     );
 
     // Score lookup keyed by _id

--- a/packages/backend/convex/functions/instructions.ts
+++ b/packages/backend/convex/functions/instructions.ts
@@ -171,7 +171,7 @@ export async function getInstructionForUserById(
     .withIndex("by_instructionId", (q) => q.eq("instructionId", instructionId))
     .first();
 
-  if (!instruction || instruction.userId !== userId) {
+  if (instruction?.userId !== userId) {
     return null;
   }
 
@@ -288,7 +288,7 @@ export const createInstruction = mutation({
       instructionId,
       userId: ctx.userId,
       name: normalizeName(args.name),
-      description: args.description?.trim() || "Custom instruction",
+      description: args.description?.trim() ?? "Custom instruction",
       prompt: normalizePrompt(args.prompt),
       userEdited: true,
       createdAt: now,
@@ -444,7 +444,7 @@ export const getBuiltinInstructionMeta = query({
   args: {
     builtinKey: v.string(),
   },
-  handler: async (_ctx, args) => {
+  handler: (_ctx, args) => {
     if (!isBuiltinInstructionKey(args.builtinKey)) {
       throw new ConvexError("Unknown built-in instruction");
     }

--- a/packages/backend/convex/functions/projects.ts
+++ b/packages/backend/convex/functions/projects.ts
@@ -1,8 +1,9 @@
+import type { GenericMutationCtx } from "convex/server";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
-import { api, internal } from "../_generated/api";
-import { backendEnv } from "../env";
+import { internal } from "../_generated/api";
+import type { DataModel } from "../_generated/dataModel";
 import { mutation, query } from "./index";
 
 function generateProjectId() {
@@ -18,6 +19,20 @@ function normalizeOptionalText(value: string | undefined) {
     return undefined;
   }
   return value;
+}
+
+async function deleteAttachmentEmbeddings(
+  ctx: GenericMutationCtx<DataModel>,
+  attachmentId: string,
+) {
+  const rows = await ctx.db
+    .query("attachmentEmbeddings")
+    .withIndex("by_attachmentId", (q) => q.eq("attachmentId", attachmentId))
+    .collect();
+
+  for (const row of rows) {
+    await ctx.db.delete(row._id);
+  }
 }
 
 export const createProject = mutation({
@@ -181,7 +196,6 @@ export const deleteProject = mutation({
       )
       .collect();
 
-    const secret = backendEnv().INTERNAL_CONVEX_SECRET;
     for (const file of projectFiles) {
       if (file.userId !== ctx.userId) continue;
       await ctx.scheduler.runAfter(
@@ -194,12 +208,8 @@ export const deleteProject = mutation({
           accessKey: file.accessKey,
         },
       );
+      await deleteAttachmentEmbeddings(ctx, file.attachmentId);
       await ctx.db.delete(file._id);
-      await ctx.scheduler.runAfter(
-        0,
-        api.functions.embeddings.internal_deleteEmbeddingsForAttachment,
-        { secret, attachmentId: file.attachmentId },
-      );
     }
 
     await ctx.db.delete(project._id);
@@ -304,15 +314,8 @@ export const deleteProjectFile = mutation({
         accessKey: attachment.accessKey,
       },
     );
+    await deleteAttachmentEmbeddings(ctx, args.attachmentId);
     await ctx.db.delete(attachment._id);
-    await ctx.scheduler.runAfter(
-      0,
-      api.functions.embeddings.internal_deleteEmbeddingsForAttachment,
-      {
-        secret: backendEnv().INTERNAL_CONVEX_SECRET,
-        attachmentId: args.attachmentId,
-      },
-    );
     return { success: true };
   },
 });

--- a/packages/backend/convex/functions/threads.ts
+++ b/packages/backend/convex/functions/threads.ts
@@ -451,7 +451,7 @@ export const internal_failStream = backendMutation({
       )
       .first();
 
-    if (assistantMessage && assistantMessage.role === "assistant") {
+    if (assistantMessage?.role === "assistant") {
       await ctx.db.patch(assistantMessage._id, {
         status: "failed",
         error: args.error,

--- a/packages/backend/convex/functions/threads.ts
+++ b/packages/backend/convex/functions/threads.ts
@@ -1,5 +1,5 @@
 import type { UIDataTypes, UIMessagePart, UITools } from "ai";
-import type { GenericMutationCtx } from "convex/server";
+import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText } from "ai";
 import { Buffer } from "buffer/";
@@ -38,6 +38,10 @@ type AuthenticatedMutationCtx = GenericMutationCtx<DataModel> & {
   userId: string;
 };
 
+type ThreadReadCtx =
+  | GenericMutationCtx<DataModel>
+  | GenericQueryCtx<DataModel>;
+
 const messageSettingsValidator = v.object({
   model: v.string(),
   instructionId: v.optional(v.string()),
@@ -55,12 +59,20 @@ async function getThreadForUser(
   ctx: AuthenticatedMutationCtx,
   threadId: string,
 ) {
+  return getThreadForOwner(ctx, threadId, ctx.userId);
+}
+
+async function getThreadForOwner(
+  ctx: ThreadReadCtx,
+  threadId: string,
+  userId: string,
+) {
   const thread = await ctx.db
     .query("threads")
     .withIndex("by_threadId", (q) => q.eq("threadId", threadId))
     .first();
 
-  if (thread?.userId !== ctx.userId) {
+  if (thread?.userId !== userId) {
     throw new ConvexError("Thread not found");
   }
 
@@ -69,6 +81,14 @@ async function getThreadForUser(
 
 async function getMessageForThread(
   ctx: AuthenticatedMutationCtx,
+  threadId: string,
+  messageId: string,
+) {
+  return getMessageForThreadId(ctx, threadId, messageId);
+}
+
+async function getMessageForThreadId(
+  ctx: ThreadReadCtx,
   threadId: string,
   messageId: string,
 ) {
@@ -292,23 +312,12 @@ export const getThread = query({
 export const abortStream = mutation({
   args: { threadId: v.string(), messageId: v.string() },
   handler: async (ctx, args) => {
-    const thread = await ctx.db
-      .query("threads")
-      .filter((q) => q.eq(q.field("threadId"), args.threadId))
-      .first();
-
-    if (thread?.userId != ctx.userId) {
-      throw new ConvexError("Thread not found");
-    }
-
-    const message = await ctx.db
-      .query("messages")
-      .filter((q) => q.eq(q.field("messageId"), args.messageId))
-      .first();
-
-    if (message?.threadId != args.threadId) {
-      throw new ConvexError("Message not found");
-    }
+    const thread = await getThreadForOwner(ctx, args.threadId, ctx.userId);
+    const message = await getMessageForThreadId(
+      ctx,
+      args.threadId,
+      args.messageId,
+    );
 
     await ctx.db.patch(message._id, {
       canceledAt: Date.now(),
@@ -334,8 +343,7 @@ export const getThreadMessages = query({
     }
 
     if (thread.userId !== ctx.userId) {
-      console.log(thread.userId, ctx.userId);
-      throw new ConvexError("Unauthorized");
+      throw new ConvexError("Thread not found");
     }
 
     // Get all messages for this thread
@@ -392,30 +400,24 @@ export const getThreadMessages = query({
 // Complete the stream - update assistant message with final content
 export const internal_completeStream = backendMutation({
   args: {
+    userId: v.string(),
     threadId: v.string(),
     assistantMessageId: v.string(),
     parts: v.array(v.any()),
   },
   handler: async (ctx, args) => {
-    const assistantMessage = await ctx.db
-      .query("messages")
-      .filter((q) => q.eq(q.field("messageId"), args.assistantMessageId))
-      .first();
-
-    if (!assistantMessage) {
+    const thread = await getThreadForOwner(ctx, args.threadId, args.userId);
+    const assistantMessage = await getMessageForThreadId(
+      ctx,
+      args.threadId,
+      args.assistantMessageId,
+    );
+    if (assistantMessage.role !== "assistant") {
       throw new ConvexError("Assistant message not found");
     }
 
     if (assistantMessage.canceledAt || assistantMessage.status === "failed") {
-      const thread = await ctx.db
-        .query("threads")
-        .filter((q) => q.eq(q.field("threadId"), args.threadId))
-        .first();
-
-      if (thread) {
-        await cleanupInactiveStreamThread(ctx, thread);
-      }
-
+      await cleanupInactiveStreamThread(ctx, thread);
       return { success: false };
     }
 
@@ -423,15 +425,6 @@ export const internal_completeStream = backendMutation({
       parts: args.parts as UIMessagePart<UIDataTypes, UITools>[],
       status: "completed",
     });
-
-    const thread = await ctx.db
-      .query("threads")
-      .filter((q) => q.eq(q.field("threadId"), args.threadId))
-      .first();
-
-    if (!thread) {
-      throw new ConvexError("Thread not found");
-    }
 
     await cleanupInactiveStreamThread(ctx, thread);
 
@@ -441,11 +434,13 @@ export const internal_completeStream = backendMutation({
 
 export const internal_failStream = backendMutation({
   args: {
+    userId: v.string(),
     threadId: v.string(),
     assistantMessageId: v.string(),
     error: v.string(),
   },
   handler: async (ctx, args) => {
+    const thread = await getThreadForOwner(ctx, args.threadId, args.userId);
     // we errored
     const assistantMessage = await ctx.db
       .query("messages")
@@ -456,21 +451,16 @@ export const internal_failStream = backendMutation({
       )
       .first();
 
-    if (assistantMessage) {
+    if (assistantMessage && assistantMessage.role === "assistant") {
       await ctx.db.patch(assistantMessage._id, {
         status: "failed",
         error: args.error,
       });
+    } else if (assistantMessage) {
+      throw new ConvexError("Assistant message not found");
     }
 
-    const thread = await ctx.db
-      .query("threads")
-      .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId))
-      .first();
-
-    if (thread) {
-      await cleanupInactiveStreamThread(ctx, thread);
-    }
+    await cleanupInactiveStreamThread(ctx, thread);
 
     return { success: assistantMessage !== null };
   },
@@ -478,6 +468,8 @@ export const internal_failStream = backendMutation({
 
 export const internal_updateMessageUsage = backendMutation({
   args: {
+    userId: v.string(),
+    threadId: v.string(),
     messageId: v.string(),
     usage: v.object({
       promptTokens: v.number(),
@@ -493,12 +485,14 @@ export const internal_updateMessageUsage = backendMutation({
     ),
   },
   handler: async (ctx, args) => {
-    const message = await ctx.db
-      .query("messages")
-      .filter((q) => q.eq(q.field("messageId"), args.messageId))
-      .first();
-    if (!message) {
-      throw new ConvexError("Message not found");
+    await getThreadForOwner(ctx, args.threadId, args.userId);
+    const message = await getMessageForThreadId(
+      ctx,
+      args.threadId,
+      args.messageId,
+    );
+    if (message.role !== "assistant") {
+      throw new ConvexError("Assistant message not found");
     }
     await ctx.db.patch(message._id, {
       usage: args.usage,
@@ -510,19 +504,21 @@ export const internal_updateMessageUsage = backendMutation({
 // Set the active stream ID for resumable streams
 export const internal_setActiveStreamId = backendMutation({
   args: {
+    userId: v.string(),
     threadId: v.string(),
     streamId: v.string(),
     messageId: v.string(),
     clientId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const thread = await ctx.db
-      .query("threads")
-      .filter((q) => q.eq(q.field("threadId"), args.threadId))
-      .first();
-
-    if (!thread) {
-      throw new ConvexError("Thread not found");
+    const thread = await getThreadForOwner(ctx, args.threadId, args.userId);
+    const message = await getMessageForThreadId(
+      ctx,
+      args.threadId,
+      args.messageId,
+    );
+    if (message.role !== "assistant") {
+      throw new ConvexError("Assistant message not found");
     }
 
     await ctx.db.patch(thread._id, {
@@ -535,22 +531,17 @@ export const internal_setActiveStreamId = backendMutation({
 });
 
 export const internal_checkMessageAbort = backendQuery({
-  args: { messageId: v.string(), threadId: v.string() },
+  args: { userId: v.string(), messageId: v.string(), threadId: v.string() },
   handler: async (ctx, args) => {
+    await getThreadForOwner(ctx, args.threadId, args.userId);
     const message = await ctx.db
       .query("messages")
-      .filter((q) => q.eq(q.field("messageId"), args.messageId))
+      .withIndex("by_threadId_messageId", (q) =>
+        q.eq("threadId", args.threadId).eq("messageId", args.messageId),
+      )
       .first();
 
     if (!message) {
-      // check if we deleted the thread
-      const thread = await ctx.db
-        .query("threads")
-        .filter((q) => q.eq(q.field("threadId"), args.threadId))
-        .first();
-      if (!thread) {
-        return true;
-      }
       throw new ConvexError("Message not found");
     }
     return message.canceledAt;

--- a/packages/backend/convex/functions/user.ts
+++ b/packages/backend/convex/functions/user.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 
 import { authComponent } from "../auth";
 import { backendEnv } from "../env";
-import { mutation, query } from "./index";
+import { query } from "./index";
 
 export const getUserImage = query({
   args: {
@@ -15,10 +15,6 @@ export const getUserImage = query({
     }
 
     const target = await authComponent.getAuthUser(ctx);
-
-    if (!target) {
-      throw new Error("User not found");
-    }
 
     if (typeof target.image === "string" && target.image) {
       if (target.image.startsWith("http")) {

--- a/packages/backend/convex/functions/user.ts
+++ b/packages/backend/convex/functions/user.ts
@@ -10,13 +10,11 @@ export const getUserImage = query({
     userId: v.optional(v.string()),
   },
   handler: async (ctx, { userId }) => {
-    let target = null;
-
-    if (userId && userId !== "me") {
-      target = await authComponent.getAnyUserById(ctx, userId);
-    } else {
-      target = await authComponent.getAuthUser(ctx);
+    if (userId && userId !== "me" && userId !== ctx.userId) {
+      throw new Error("User not found");
     }
+
+    const target = await authComponent.getAuthUser(ctx);
 
     if (!target) {
       throw new Error("User not found");
@@ -32,12 +30,6 @@ export const getUserImage = query({
       };
     }
     return { image: null };
-  },
-});
-
-export const testMutation = mutation({
-  handler: (ctx) => {
-    return ctx.user;
   },
 });
 
@@ -64,12 +56,6 @@ export const verifySignature = async (
 
   return crypto.subtle.verify("HMAC", key, signatureBuffer, messageData);
 };
-export const testQuery = query({
-  handler: () => {
-    return "testQuery";
-  },
-});
-
 export const getCurrentUserId = query({
   handler: (_ctx) => {
     return { userId: _ctx.userId };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Require authenticated user context and ownership checks for secret-gated stream mutations before updating thread/message state.
- Verify thread/project/attachment ownership for uploads, attachment linking, and project RAG embedding writes/reads.
- Remove user avatar enumeration and debug user/session disclosure endpoints.

## Problems found and fixed
1. Secret-gated stream mutations (`internal_completeStream`, `internal_failStream`, `internal_updateMessageUsage`, `internal_setActiveStreamId`, `internal_checkMessageAbort`) trusted client-provided thread/message IDs. These now require the request user ID and verify the thread owner plus message membership/role before mutating or reading stream state.
2. `/api/chat` used the internal Convex secret with request body IDs without independently resolving the request user. It now authenticates the request headers first and passes the authenticated user ID into all hardened internal calls.
3. `attachToMessage` / `attachDraftAttachmentsToMessage` could attach a user's draft attachments to an arbitrary known thread/message ID. The helper now verifies the target thread belongs to the caller and the message exists on that thread.
4. Upload completion (`internal_createUploadedAttachment`) trusted caller-supplied `userId`, `threadId`, and `chatProjectId`. It now validates that any target thread/project belongs to the supplied user, rejects mixed thread/project targets, requires expiring drafts, and prevents overwriting another user's attachment record.
5. Project attachment upload middleware accepted any `chatProjectId` and chat attachment uploads accepted any optional `threadId`. It now resolves those IDs through authenticated Convex queries before accepting uploads.
6. Embedding maintenance functions (`internal_upsertEmbeddings`, `internal_deleteEmbeddingsForAttachment`, `internal_setAttachmentEmbeddingStatus`, `internal_getAttachmentSummaries`) were secret-only and could operate on arbitrary attachments. They now require `userId` and verify project attachment ownership before writing or returning sensitive attachment access keys.
7. Project-file deletion deleted attachment rows before scheduled embedding cleanup, which conflicted with ownership-checked cleanup. It now deletes embeddings while the owned attachment row still exists, then deletes storage metadata.
8. `getUserImage` allowed probing arbitrary user IDs via `getAnyUserById`. It now only returns the authenticated user's image (or `me`) and rejects other user IDs.
9. Debug Convex functions exposed `ctx.user` / test query data to authenticated clients. They were removed.
10. Unauthorized `getThreadMessages` logged both stored and caller user IDs. That privacy leak was removed.

## Verification
- `pnpm -F @redux/backend typecheck`
- `pnpm -F @redux/tanstack-start typecheck`
- `pnpm -F @redux/backend lint`
- `pnpm -F @redux/tanstack-start exec eslint --flag unstable_native_nodejs_ts_config src/lib/ai/tools/search-project.ts src/routes/api/chat/index.ts src/server/rag/convex-vector-store.ts src/server/rag/index-attachment.ts src/server/rag/retrieve.ts src/server/rag/vector-store.ts src/upload.ts`

Note: full `pnpm -F @redux/tanstack-start lint` still fails on pre-existing unrelated files (`components/chat/index.tsx`, `components/chat/input/index.tsx`, `components/settings/instructions-manager.tsx`, `routes/_app.tsx`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae98a164-b697-41d5-98b3-4f28191c6be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae98a164-b697-41d5-98b3-4f28191c6be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

