### PR TITLE
Plan switching with Polar invoice / next_period proration

### DIFF
--- a/apps/tanstack-start/src/routes/settings/index.tsx
+++ b/apps/tanstack-start/src/routes/settings/index.tsx
@@ -283,7 +283,7 @@ function RouteComponent() {
                 <>
                   Nothing changes until your next renewal—you keep your current plan and
                   benefits until then. After that, you&apos;ll move to the lower plan
-                  automatically, with no extra fee for switching early.
+                  automatically.
                 </>
               )}
             </DialogDescription>

--- a/apps/tanstack-start/src/routes/settings/index.tsx
+++ b/apps/tanstack-start/src/routes/settings/index.tsx
@@ -10,6 +10,14 @@ import { ChevronRight, RefreshCw } from "lucide-react";
 import { api } from "@redux/backend/convex/_generated/api";
 import { Button, buttonVariants } from "@redux/ui/components/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@redux/ui/components/dialog";
+import {
   Progress,
   ProgressLabel,
   ProgressValue,
@@ -75,6 +83,7 @@ function RouteComponent() {
   const polarProducts = useQuery(api.polar.getConfiguredProducts, {});
   const baseBillingState = useQuery(api.functions.billing.getCurrentBillingState, {});
   const refreshMeterState = useAction(api.functions.billing.refreshCurrentUserMeterState);
+  const switchPaidPlan = useAction(api.functions.billing.switchCurrentUserPaidPlan);
   const [liveMeterState, setLiveMeterState] = useState<
     | {
         tier: PlanTier;
@@ -87,6 +96,12 @@ function RouteComponent() {
   >(undefined);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
+  const [planSwitchConfirm, setPlanSwitchConfirm] = useState<{
+    productId: string;
+    planName: string;
+    isUpgrade: boolean;
+  } | null>(null);
+  const [planSwitchLoading, setPlanSwitchLoading] = useState(false);
 
   const billingState = useMemo(() => {
     if (!baseBillingState) {
@@ -182,6 +197,7 @@ function RouteComponent() {
 
   const subscriptionId = billingState?.subscription?.subscriptionId;
   const showPaidManage = tierRank(currentTier) >= 1;
+  const isOnPaidPlan = showPaidManage;
 
   const renewSummary = renewalSummary(billingState?.currentPeriodEnd);
 
@@ -189,6 +205,30 @@ function RouteComponent() {
     "inline-flex h-9 w-full cursor-pointer items-center justify-center rounded-md px-3 text-sm font-medium outline-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 pointer-events-auto";
 
   const rank = tierRank(currentTier);
+
+  const confirmPlanSwitch = async () => {
+    if (!planSwitchConfirm) {
+      return;
+    }
+    setPlanSwitchLoading(true);
+    setSyncError(null);
+    try {
+      await switchPaidPlan({ productId: planSwitchConfirm.productId });
+      setPlanSwitchConfirm(null);
+      const result = await refreshMeterState({});
+      setLiveMeterState({
+        tier: result.tier,
+        availableCredits: result.availableCredits,
+        overageCredits: result.overageCredits,
+        overageAllowed: result.overageAllowed,
+        syncedAt: Date.now(),
+      });
+    } catch (error) {
+      setSyncError(error instanceof Error ? error.message : "Plan switch failed");
+    } finally {
+      setPlanSwitchLoading(false);
+    }
+  };
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 pb-8">
@@ -220,6 +260,52 @@ function RouteComponent() {
           ) : null}
         </div>
       </div>
+
+      <Dialog
+        open={planSwitchConfirm !== null}
+        onOpenChange={(open) => {
+          if (!open && !planSwitchLoading) {
+            setPlanSwitchConfirm(null);
+          }
+        }}
+      >
+        <DialogContent showCloseButton={!planSwitchLoading}>
+          <DialogHeader>
+            <DialogTitle>Switch to {planSwitchConfirm?.planName}?</DialogTitle>
+            <DialogDescription>
+              {planSwitchConfirm?.isUpgrade ? (
+                <>
+                  Your subscription updates now and Polar bills the prorated upgrade
+                  immediately on a separate invoice (not deferred to the next renewal).
+                </>
+              ) : (
+                <>
+                  The lower plan is scheduled for the start of your next billing period.
+                  You keep your current benefits until then; there is no mid-cycle credit or
+                  downgrade charge.
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPlanSwitchConfirm(null)}
+              disabled={planSwitchLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void confirmPlanSwitch()}
+              disabled={planSwitchLoading}
+            >
+              {planSwitchLoading ? "Switching…" : "Confirm switch"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <section className="space-y-3">
         <p className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
@@ -259,6 +345,11 @@ function RouteComponent() {
         <p className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
           Plans
         </p>
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          New subscriptions use checkout. If you already pay for Plus or Pro, you can switch
+          plans here (upgrades bill now; downgrades apply at renewal). Use Manage billing for
+          payment method, invoices, and cancellation.
+        </p>
         <div className="grid gap-4 lg:grid-cols-3">
           <TierColumn
             name="Free"
@@ -273,7 +364,7 @@ function RouteComponent() {
             name="Plus"
             plan={getPlanConfig("plus", billingConfig)}
             priceLabel={formatPolarRecurringPrice(plusProduct ?? undefined)}
-            state={rank === 1 ? "current" : rank === 0 ? "available" : "inactive"}
+            state={rank === 1 ? "current" : rank === 0 ? "available" : "available"}
             polarApi={polarApi}
             checkoutAnchorClass={checkoutAnchorClass}
             productId={plusProduct?.id}
@@ -281,6 +372,19 @@ function RouteComponent() {
             buttonLabel="Plus"
             emphasize={rank === 0}
             renewalSummary={renewSummary}
+            paidSwitch={
+              isOnPaidPlan && rank === 2 && plusProduct?.id
+                ? {
+                    isUpgrade: false,
+                    onRequest: () =>
+                      setPlanSwitchConfirm({
+                        productId: plusProduct.id,
+                        planName: "Plus",
+                        isUpgrade: false,
+                      }),
+                  }
+                : undefined
+            }
           />
           <TierColumn
             name="Pro"
@@ -294,6 +398,19 @@ function RouteComponent() {
             buttonLabel="Pro"
             emphasize={rank === 1}
             renewalSummary={renewSummary}
+            paidSwitch={
+              isOnPaidPlan && rank === 1 && proProduct?.id
+                ? {
+                    isUpgrade: true,
+                    onRequest: () =>
+                      setPlanSwitchConfirm({
+                        productId: proProduct.id,
+                        planName: "Pro",
+                        isUpgrade: true,
+                      }),
+                  }
+                : undefined
+            }
           />
         </div>
       </section>
@@ -331,6 +448,7 @@ function TierColumn({
   emphasize,
   buttonLabel,
   renewalSummary: renewalLine,
+  paidSwitch,
 }: {
   name: string;
   plan: ReturnType<typeof getPlanConfig>;
@@ -343,6 +461,7 @@ function TierColumn({
   emphasize?: boolean;
   buttonLabel?: string;
   renewalSummary?: string | null;
+  paidSwitch?: { isUpgrade: boolean; onRequest: () => void };
 }) {
   const priced =
     priceLabel !== undefined
@@ -358,6 +477,18 @@ function TierColumn({
       </Button>
     ) : state === "inactive" ? (
       <div className="mt-auto pt-6" aria-hidden />
+    ) : productId !== undefined && paidSwitch ? (
+      <Button
+        type="button"
+        variant={emphasize ? "default" : "outline"}
+        size="sm"
+        className={cn("mt-auto w-full text-xs", !emphasize && "bg-transparent")}
+        onClick={paidSwitch.onRequest}
+      >
+        {paidSwitch.isUpgrade
+          ? `Upgrade to ${buttonLabel ?? name}`
+          : `Downgrade to ${buttonLabel ?? name} (next renewal)`}
+      </Button>
     ) : productId !== undefined ? (
       <CheckoutLink
         polarApi={polarApi}

--- a/apps/tanstack-start/src/routes/settings/index.tsx
+++ b/apps/tanstack-start/src/routes/settings/index.tsx
@@ -275,14 +275,15 @@ function RouteComponent() {
             <DialogDescription>
               {planSwitchConfirm?.isUpgrade ? (
                 <>
-                  Your subscription updates now and Polar bills the prorated upgrade
-                  immediately on a separate invoice (not deferred to the next renewal).
+                  Your new plan starts right away. You&apos;ll pay a one-time amount for the
+                  rest of this billing period (it appears as its own line on your statement),
+                  then your usual renewal price after that.
                 </>
               ) : (
                 <>
-                  The lower plan is scheduled for the start of your next billing period.
-                  You keep your current benefits until then; there is no mid-cycle credit or
-                  downgrade charge.
+                  Nothing changes until your next renewal—you keep your current plan and
+                  benefits until then. After that, you&apos;ll move to the lower plan
+                  automatically, with no extra fee for switching early.
                 </>
               )}
             </DialogDescription>
@@ -346,9 +347,10 @@ function RouteComponent() {
           Plans
         </p>
         <p className="text-muted-foreground text-xs leading-relaxed">
-          New subscriptions use checkout. If you already pay for Plus or Pro, you can switch
-          plans here (upgrades bill now; downgrades apply at renewal). Use Manage billing for
-          payment method, invoices, and cancellation.
+          Pick a paid plan below to subscribe. Already on Plus or Pro? You can switch between
+          those two here—upgrades start today with a one-time charge for the rest of this
+          period; downgrades take effect on your next renewal. For your card, receipts, or to
+          cancel, open Manage billing.
         </p>
         <div className="grid gap-4 lg:grid-cols-3">
           <TierColumn

--- a/packages/backend/convex/functions/billing.ts
+++ b/packages/backend/convex/functions/billing.ts
@@ -22,6 +22,30 @@ import {
 import { polar } from "../polar";
 import { action, query } from "./index";
 
+function planTierRank(tier: PlanTier): number {
+  if (tier === "free") {
+    return 0;
+  }
+  if (tier === "plus") {
+    return 1;
+  }
+  return 2;
+}
+
+function tierFromPolarProductId(productId: string): PlanTier {
+  const env = backendEnv();
+  if (productId === env.POLAR_FREE_PRODUCT_ID) {
+    return "free";
+  }
+  if (productId === env.POLAR_PLUS_PRODUCT_ID) {
+    return "plus";
+  }
+  if (productId === env.POLAR_PRO_PRODUCT_ID) {
+    return "pro";
+  }
+  throw new Error("That product is not a configured plan.");
+}
+
 type BillingActionCtx = GenericActionCtx<DataModel> & {
   userId: string;
 };
@@ -115,6 +139,65 @@ export const refreshCurrentUserMeterState = action({
   args: {},
   handler: async (ctx): Promise<BillingRefreshResult> => {
     return await refreshBillingStateForUser(ctx, ctx.userId);
+  },
+});
+
+/**
+ * Switch between Plus and Pro with per-call Polar proration: upgrades use
+ * `invoice` (charge now); downgrades use `next_period` (change at renewal).
+ * Free users must use checkout instead.
+ */
+export const switchCurrentUserPaidPlan = action({
+  args: { productId: v.string() },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ prorationBehavior: "invoice" | "next_period"; targetTier: PlanTier }> => {
+    const subscriptionState = await resolveCurrentSubscriptionState(ctx, ctx.userId);
+    if (subscriptionState.tier === "free") {
+      throw new Error(
+        "Use checkout to subscribe. Plan switches from this page are only for existing paid subscriptions.",
+      );
+    }
+
+    let targetTier: PlanTier;
+    try {
+      targetTier = tierFromPolarProductId(args.productId);
+    } catch {
+      throw new Error("That product is not a configured plan.");
+    }
+
+    if (targetTier === "free") {
+      throw new Error(
+        "Moving to the free tier is not available here. Cancel from Manage billing when you want to end a paid plan.",
+      );
+    }
+
+    const subscription = subscriptionState.subscription;
+    const subscriptionId = subscription?.subscriptionId;
+    if (!subscriptionId) {
+      throw new Error("No subscription found to update.");
+    }
+
+    if (subscription?.productId === args.productId) {
+      throw new Error("You are already on this plan.");
+    }
+
+    const fromRank = planTierRank(subscriptionState.tier);
+    const toRank = planTierRank(targetTier);
+    const prorationBehavior =
+      toRank > fromRank ? ("invoice" as const) : ("next_period" as const);
+
+    const polarSdk = getPolarSdkClient();
+    await polarSdk.subscriptions.update({
+      id: subscriptionId,
+      subscriptionUpdate: {
+        productId: args.productId,
+        prorationBehavior,
+      },
+    });
+
+    return { prorationBehavior, targetTier };
   },
 });
 

--- a/packages/backend/convex/polar.ts
+++ b/packages/backend/convex/polar.ts
@@ -23,7 +23,6 @@ export const polar: Polar<DataModel> = new Polar<DataModel>(components.polar, {
 });
 
 export const {
-  changeCurrentSubscription,
   cancelCurrentSubscription,
   getConfiguredProducts,
   listAllProducts,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements paid-tier plan changes from the app settings billing page with explicit Polar proration behavior per [Polar proration docs](https://docs.polar.sh/features/subscriptions/proration): upgrades use `invoice` (immediate charge); downgrades use `next_period` (scheduled at renewal, no mid-cycle credit).

## Backend

- Adds `api.functions.billing.switchCurrentUserPaidPlan` which calls `polarSdk.subscriptions.update` with `prorationBehavior` derived from tier rank (Plus/Pro only; free tier and arbitrary product IDs are rejected).
- Stops exporting `changeCurrentSubscription` from `packages/backend/convex/polar.ts` because `@convex-dev/polar` calls `subscriptionsUpdate` without `prorationBehavior`, so it would follow the organization default (including the `prorate` path the product owner wanted to avoid for this flow).

## Frontend

- Free users: unchanged checkout `CheckoutLink` for Plus/Pro.
- Paid users: Plus↔Pro switches use a confirmation dialog, then the new action; Pro→Plus column is `available` when on Pro so downgrades are reachable (previously marked inactive).
- Billing copy in the dialog and under Plans is written for end users (no vendor jargon).

## Manual follow-up (Polar dashboard)

Under **Settings → Billing → Customer portal**, disable customer-initiated subscription plan changes so only cancellation (and other allowed actions) remain in the hosted portal, matching the intent described in the task.

## Testing

Node/pnpm were not available in this agent environment, so `convex codegen`, lint, and tests were not run here. Please run your usual CI or `npx convex dev` / `pnpm` checks locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7e6c5aa-152d-4e0e-b7c7-561656691bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7e6c5aa-152d-4e0e-b7c7-561656691bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

