### PR TITLE
Fix Polar customer mapping for webhook credit grants

### DIFF
--- a/packages/backend/convex/functions/billing.ts
+++ b/packages/backend/convex/functions/billing.ts
@@ -638,6 +638,7 @@ async function ensurePolarCustomerForCurrentUser(ctx: BillingActionCtx) {
       // });
       const customer = await polarSdk.customers.create({
         email: user.email,
+        externalId: user.userId,
         // avatarUrl: image.image ?? undefined,
         metadata: {
           userId: user.userId,


### PR DESCRIPTION
### Motivation
- Ensure newly-created Polar customers include an `externalId` so webhook handlers that map events by `customer.externalId` can resolve the owning user and correctly grant/revoke credits.

### Description
- Add `externalId: user.userId` to the `polarSdk.customers.create` call in `packages/backend/convex/functions/billing.ts` within `ensurePolarCustomerForCurrentUser` so new customers are created with the external ID mapping.

### Testing
- Ran `pnpm -F @redux/backend typecheck`, which failed due to pre-existing repository/environment type and missing-dependency issues (e.g. `@better-auth/core`, `convex-test`, `vitest`), and not because of this one-line change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8c7d76e483329f9b1df85358c42e)