### PR TITLE
Refactor tool settings to explicit enabled/disabled states

### DIFF
--- a/apps/tanstack-start/src/components/chat/input/index.tsx
+++ b/apps/tanstack-start/src/components/chat/input/index.tsx
@@ -20,7 +20,11 @@ import {
   resolveModelAttachmentDelivery,
   resolveModelRoute,
 } from "@redux/shared/models";
-import { isToolEnabled } from "@redux/types";
+import {
+  getImageGenerationToolModelId,
+  getMcpServerIds,
+  isToolEnabled,
+} from "@redux/types";
 import { useSidebar } from "@redux/ui/components/sidebar";
 import { cn } from "@redux/ui/lib/utils";
 
@@ -267,14 +271,14 @@ export function ChatInput({
     [],
   );
   const selectedImageGenerationModelId =
-    settings.tools.imageGeneration?.modelId ?? imageGenerationModels[0]?.id;
+    getImageGenerationToolModelId(settings.tools) ?? imageGenerationModels[0]?.id;
   const isImageGenerationEnabled = isToolEnabled(
     settings.tools,
     "imageGeneration",
   );
   const enabledMcpServerIds = useMemo(
-    () => settings.tools.mcpServers?.serverIds ?? [],
-    [settings.tools.mcpServers],
+    () => getMcpServerIds(settings.tools),
+    [settings.tools],
   );
   const showErrorBorder = status === "error";
   const selectedInstruction =
@@ -376,7 +380,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          search: enabled ? {} : undefined,
+          search: enabled ? {} : false,
         },
       });
     },
@@ -387,7 +391,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          analysisWorkspace: enabled ? { syncUploads: true } : undefined,
+          analysisWorkspace: enabled ? {} : false,
         },
       });
     },
@@ -398,14 +402,11 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          imageGeneration:
-            enabled && selectedImageGenerationModelId
-              ? { modelId: selectedImageGenerationModelId }
-              : undefined,
+          imageGeneration: enabled ? {} : false,
         },
       });
     },
-    [onSettingsChange, selectedImageGenerationModelId],
+    [onSettingsChange],
   );
 
   const handleImageGenerationModelChange = useCallback(
@@ -423,7 +424,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          bashWorkspace: enabled ? {} : undefined,
+          bashWorkspace: enabled ? {} : false,
         },
       });
     },
@@ -489,8 +490,7 @@ export function ChatInput({
 
       void onSettingsChange({
         tools: {
-          mcpServers:
-            nextServerIds.length > 0 ? { serverIds: nextServerIds } : undefined,
+          mcpServers: nextServerIds.length > 0 ? { serverIds: nextServerIds } : {},
         },
       });
     },

--- a/apps/tanstack-start/src/components/chat/use-chat-settings.ts
+++ b/apps/tanstack-start/src/components/chat/use-chat-settings.ts
@@ -92,15 +92,30 @@ export function useChatSettings(
       }
 
       try {
-        const nextSettings = threadId
-          ? normalizeMessageSettings(
-              (
-                await convex.query(api.functions.threads.getThread, {
-                  threadId,
-                })
-              )?.settings,
-            )
-          : normalizeMessageSettings(await getDefaultSettings({}));
+        let nextSettings: MessageSettings;
+        if (threadId) {
+          const thread = await convex.query(api.functions.threads.getThread, {
+            threadId,
+          });
+          nextSettings = normalizeMessageSettings(thread?.settings);
+
+          // When new tools are introduced, heal older thread documents so they
+          // persist canonical enabled values instead of missing/null states.
+          if (
+            thread &&
+            JSON.stringify(nextSettings.tools) !==
+              JSON.stringify(thread.settings.tools)
+          ) {
+            await updateThreadSettings({
+              threadId,
+              patch: {
+                tools: nextSettings.tools,
+              },
+            });
+          }
+        } else {
+          nextSettings = normalizeMessageSettings(await getDefaultSettings({}));
+        }
 
         if (!cancelled) {
           setSettings(nextSettings);
@@ -134,6 +149,7 @@ export function useChatSettings(
     scopeKey,
     session?.session.userId,
     threadId,
+    updateThreadSettings,
   ]);
 
   const updateSettings = useCallback(

--- a/apps/tanstack-start/src/lib/ai/tools/index.ts
+++ b/apps/tanstack-start/src/lib/ai/tools/index.ts
@@ -13,7 +13,11 @@ import { z } from "zod";
 import type { BillableToolCall, ToolBillingKey } from "@redux/shared";
 import type { MessageSettings } from "@redux/types";
 import { isImageGenerationToolModel } from "@redux/shared/models";
-import { getEnabledMessageTools } from "@redux/types";
+import {
+  getAnalysisWorkspaceSyncUploads,
+  getEnabledMessageTools,
+  getImageGenerationToolModelId,
+} from "@redux/types";
 
 import { createBashWorkspaceRuntime } from "@/lib/ai/tools/bash-workspace";
 import {
@@ -307,8 +311,7 @@ export async function createToolRuntime(
   }
 
   if (enabledTools.includes("analysisWorkspace")) {
-    const uploadsEnabled =
-      settings.tools.analysisWorkspace?.syncUploads !== false;
+    const uploadsEnabled = getAnalysisWorkspaceSyncUploads(settings.tools);
 
     sandboxRuntime = createSandboxRuntime({
       attachments,
@@ -412,7 +415,7 @@ export async function createToolRuntime(
   }
 
   if (enabledTools.includes("imageGeneration")) {
-    const modelId = settings.tools.imageGeneration?.modelId;
+    const modelId = getImageGenerationToolModelId(settings.tools);
     if (modelId && generationContext && isImageGenerationToolModel(modelId)) {
       tools.generate_image = instrumentTool(
         tool({

--- a/apps/tanstack-start/src/routes/api/chat/index.ts
+++ b/apps/tanstack-start/src/routes/api/chat/index.ts
@@ -20,7 +20,11 @@ import { z } from "zod";
 import type { ThinkingLevel } from "@redux/shared/models";
 import { api } from "@redux/backend/convex/_generated/api";
 import { getChatModelConfig } from "@redux/shared/models";
-import { isToolEnabled, normalizeMessageSettings } from "@redux/types";
+import {
+  getMcpServerIds,
+  isToolEnabled,
+  normalizeMessageSettings,
+} from "@redux/types";
 
 import { env } from "@/env";
 import { createToolRuntime } from "@/lib/ai/tools";
@@ -65,22 +69,36 @@ const requestBody = z.object({
     thinkingLevel: z.enum(["instant", "low", "medium", "high"]).optional(),
     instructionId: z.string().optional(),
     tools: z.object({
-      search: z.object({}).optional(),
-      bashWorkspace: z.object({}).optional(),
+      search: z.union([z.object({}), z.literal(false), z.null()]).optional(),
+      bashWorkspace: z
+        .union([z.object({}), z.literal(false), z.null()])
+        .optional(),
       analysisWorkspace: z
-        .object({
-          syncUploads: z.boolean().optional(),
-        })
+        .union([
+          z.object({
+            syncUploads: z.boolean().optional(),
+          }),
+          z.literal(false),
+          z.null(),
+        ])
         .optional(),
       mcpServers: z
-        .object({
-          serverIds: z.array(z.string()),
-        })
+        .union([
+          z.object({
+            serverIds: z.array(z.string()).optional(),
+          }),
+          z.literal(false),
+          z.null(),
+        ])
         .optional(),
       imageGeneration: z
-        .object({
-          modelId: z.string(),
-        })
+        .union([
+          z.object({
+            modelId: z.string().optional(),
+          }),
+          z.literal(false),
+          z.null(),
+        ])
         .optional(),
     }),
   }),
@@ -468,7 +486,7 @@ export const Route = createFileRoute("/api/chat/")({
           settings.tools,
           "bashWorkspace",
         );
-        const enabledMcpServerIds = settings.tools.mcpServers?.serverIds ?? [];
+        const enabledMcpServerIds = getMcpServerIds(settings.tools);
         console.log("Received request:", {
           threadId,
           assistantMessageId,

--- a/packages/backend/convex/functions/defaultMessageSettings.ts
+++ b/packages/backend/convex/functions/defaultMessageSettings.ts
@@ -62,22 +62,38 @@ export const update = mutation({
       thinkingLevel: v.optional(thinkingLevelValidator),
       tools: v.optional(
         v.object({
-          search: v.optional(v.object({})),
-          bashWorkspace: v.optional(v.object({})),
+          search: v.optional(
+            v.union(v.object({}), v.literal(false), v.null()),
+          ),
+          bashWorkspace: v.optional(
+            v.union(v.object({}), v.literal(false), v.null()),
+          ),
           analysisWorkspace: v.optional(
-            v.object({
-              syncUploads: v.optional(v.boolean()),
-            }),
+            v.union(
+              v.object({
+                syncUploads: v.optional(v.boolean()),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
           mcpServers: v.optional(
-            v.object({
-              serverIds: v.array(v.string()),
-            }),
+            v.union(
+              v.object({
+                serverIds: v.optional(v.array(v.string())),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
           imageGeneration: v.optional(
-            v.object({
-              modelId: v.string(),
-            }),
+            v.union(
+              v.object({
+                modelId: v.optional(v.string()),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
         }),
       ),

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -1,6 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getMcpServerIds } from "@redux/types";
+
 import { api } from "../_generated/api";
 import schema from "../schema";
 import { modules } from "../test.setup";
@@ -124,9 +126,9 @@ describe("functions/mcpServers", () => {
         .first();
     });
 
-    expect(defaultSettings?.settings.tools.mcpServers?.serverIds).toEqual([
-      mcpServerId,
-    ]);
+    expect(
+      defaultSettings ? getMcpServerIds(defaultSettings.settings.tools) : [],
+    ).toEqual([mcpServerId]);
   });
 
   it("removes deleted server ids from default settings and thread settings", async () => {
@@ -186,10 +188,12 @@ describe("functions/mcpServers", () => {
     });
 
     expect(
-      stored.defaultSettings?.settings.tools.mcpServers?.serverIds,
+      stored.defaultSettings
+        ? getMcpServerIds(stored.defaultSettings.settings.tools)
+        : [],
     ).toEqual([retainedServerId]);
-    expect(stored.thread?.settings.tools.mcpServers?.serverIds).toEqual([
-      retainedServerId,
-    ]);
+    expect(
+      stored.thread ? getMcpServerIds(stored.thread.settings.tools) : [],
+    ).toEqual([retainedServerId]);
   });
 });

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -1,7 +1,7 @@
 import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
-import { mergeMessageSettings } from "@redux/types";
+import { getMcpServerIds, mergeMessageSettings } from "@redux/types";
 
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { mutation, query } from "./index";
@@ -237,7 +237,7 @@ async function setMcpServersEnabled(
 function stripDeletedServerIdFromSettings<
   T extends Doc<"defaultMessageSettings"> | Doc<"threads">,
 >(doc: T, mcpServerId: string) {
-  const currentIds = doc.settings.tools.mcpServers?.serverIds ?? [];
+  const currentIds = getMcpServerIds(doc.settings.tools);
   const nextIds = currentIds.filter((serverId) => serverId !== mcpServerId);
 
   if (nextIds.length === currentIds.length) {
@@ -247,7 +247,7 @@ function stripDeletedServerIdFromSettings<
   return mergeMessageSettings(doc.settings, {
     tools: {
       ...doc.settings.tools,
-      mcpServers: nextIds.length > 0 ? { serverIds: nextIds } : undefined,
+      mcpServers: nextIds.length > 0 ? { serverIds: nextIds } : {},
     },
   });
 }
@@ -261,7 +261,9 @@ async function addServerIdToDefaultSettings(
     .query("defaultMessageSettings")
     .withIndex("by_userId", (q) => q.eq("userId", ctx.userId))
     .first();
-  const currentServerIds = existing?.settings.tools.mcpServers?.serverIds ?? [];
+  const currentServerIds = existing
+    ? getMcpServerIds(existing.settings.tools)
+    : [];
   const settings = mergeMessageSettings(existing?.settings, {
     tools: {
       mcpServers: {

--- a/packages/backend/convex/functions/threads.ts
+++ b/packages/backend/convex/functions/threads.ts
@@ -60,22 +60,34 @@ const messageSettingsValidator = v.object({
   instructionId: v.optional(v.string()),
   userMessagePreviewMaxLines: v.optional(v.number()),
   tools: v.object({
-    search: v.optional(v.object({})),
-    bashWorkspace: v.optional(v.object({})),
+    search: v.optional(v.union(v.object({}), v.literal(false), v.null())),
+    bashWorkspace: v.optional(v.union(v.object({}), v.literal(false), v.null())),
     analysisWorkspace: v.optional(
-      v.object({
-        syncUploads: v.optional(v.boolean()),
-      }),
+      v.union(
+        v.object({
+          syncUploads: v.optional(v.boolean()),
+        }),
+        v.literal(false),
+        v.null(),
+      ),
     ),
     mcpServers: v.optional(
-      v.object({
-        serverIds: v.array(v.string()),
-      }),
+      v.union(
+        v.object({
+          serverIds: v.optional(v.array(v.string())),
+        }),
+        v.literal(false),
+        v.null(),
+      ),
     ),
     imageGeneration: v.optional(
-      v.object({
-        modelId: v.string(),
-      }),
+      v.union(
+        v.object({
+          modelId: v.optional(v.string()),
+        }),
+        v.literal(false),
+        v.null(),
+      ),
     ),
   }),
 });
@@ -1264,22 +1276,38 @@ export const updateThreadSettings = mutation({
       thinkingLevel: v.optional(thinkingLevelValidator),
       tools: v.optional(
         v.object({
-          search: v.optional(v.object({})),
-          bashWorkspace: v.optional(v.object({})),
+          search: v.optional(
+            v.union(v.object({}), v.literal(false), v.null()),
+          ),
+          bashWorkspace: v.optional(
+            v.union(v.object({}), v.literal(false), v.null()),
+          ),
           analysisWorkspace: v.optional(
-            v.object({
-              syncUploads: v.optional(v.boolean()),
-            }),
+            v.union(
+              v.object({
+                syncUploads: v.optional(v.boolean()),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
           mcpServers: v.optional(
-            v.object({
-              serverIds: v.array(v.string()),
-            }),
+            v.union(
+              v.object({
+                serverIds: v.optional(v.array(v.string())),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
           imageGeneration: v.optional(
-            v.object({
-              modelId: v.string(),
-            }),
+            v.union(
+              v.object({
+                modelId: v.optional(v.string()),
+              }),
+              v.literal(false),
+              v.null(),
+            ),
           ),
         }),
       ),

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -98,22 +98,31 @@ const threadShareSettings = v.object({
 });
 
 const messageTools = v.object({
-  search: v.optional(v.object({})),
-  bashWorkspace: v.optional(v.object({})),
+  search: v.optional(v.union(v.object({}), v.literal(false))),
+  bashWorkspace: v.optional(v.union(v.object({}), v.literal(false))),
   analysisWorkspace: v.optional(
-    v.object({
-      syncUploads: v.optional(v.boolean()),
-    }),
+    v.union(
+      v.object({
+        syncUploads: v.optional(v.boolean()),
+      }),
+      v.literal(false),
+    ),
   ),
   mcpServers: v.optional(
-    v.object({
-      serverIds: v.array(v.string()),
-    }),
+    v.union(
+      v.object({
+        serverIds: v.optional(v.array(v.string())),
+      }),
+      v.literal(false),
+    ),
   ),
   imageGeneration: v.optional(
-    v.object({
-      modelId: v.string(),
-    }),
+    v.union(
+      v.object({
+        modelId: v.optional(v.string()),
+      }),
+      v.literal(false),
+    ),
   ),
 });
 

--- a/packages/types/src/chat/message-settings.ts
+++ b/packages/types/src/chat/message-settings.ts
@@ -1,5 +1,9 @@
 import type { ThinkingLevel } from "@redux/shared/models";
-import { DEFAULT_CHAT_MODEL_ID, normalizeModelId } from "@redux/shared/models";
+import {
+  DEFAULT_CHAT_MODEL_ID,
+  getImageGenerationToolModels,
+  normalizeModelId,
+} from "@redux/shared/models";
 
 export const MESSAGE_TOOL_NAMES = [
   "search",
@@ -57,6 +61,8 @@ export interface MessageToolSettingsInput {
 
 /** Lines shown before collapsing user messages in chat. Use `0` to disable collapsing. */
 export const DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES = 100;
+const DEFAULT_IMAGE_GENERATION_MODEL_ID =
+  getImageGenerationToolModels()[0]?.id;
 
 export interface MessageSettings {
   model: string;
@@ -85,6 +91,13 @@ export const DEFAULT_MESSAGE_SETTINGS: MessageSettings = {
     search: {},
     bashWorkspace: {},
     analysisWorkspace: { syncUploads: true },
+    ...(DEFAULT_IMAGE_GENERATION_MODEL_ID
+      ? {
+          imageGeneration: {
+            modelId: DEFAULT_IMAGE_GENERATION_MODEL_ID,
+          },
+        }
+      : {}),
   },
   instructionId: undefined,
   userMessagePreviewMaxLines: DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES,

--- a/packages/types/src/chat/message-settings.ts
+++ b/packages/types/src/chat/message-settings.ts
@@ -14,13 +14,15 @@ export const MESSAGE_TOOL_NAMES = [
 ] as const;
 
 export type MessageToolName = (typeof MESSAGE_TOOL_NAMES)[number];
+type MessageToolState<T> = T | false;
+type MessageToolStateInput<T> = T | false | null | undefined;
 
 export type SearchToolSettings = object;
 
 export type BashWorkspaceToolSettings = object;
 
 export interface AnalysisWorkspaceToolSettings {
-  syncUploads: boolean;
+  syncUploads?: boolean;
 }
 
 export interface AnalysisWorkspaceToolSettingsInput {
@@ -28,41 +30,51 @@ export interface AnalysisWorkspaceToolSettingsInput {
 }
 
 export interface McpServersToolSettings {
-  serverIds: string[];
+  serverIds?: string[];
 }
 
 export interface McpServersToolSettingsInput {
-  serverIds: string[];
+  serverIds?: string[];
 }
 
 export interface ImageGenerationToolSettings {
-  modelId: string;
+  modelId?: string;
 }
 
 export interface ImageGenerationToolSettingsInput {
-  modelId: string;
+  modelId?: string;
 }
 
 export interface MessageToolSettings {
-  search?: SearchToolSettings;
-  bashWorkspace?: BashWorkspaceToolSettings;
-  analysisWorkspace?: AnalysisWorkspaceToolSettings;
-  mcpServers?: McpServersToolSettings;
-  imageGeneration?: ImageGenerationToolSettings;
+  search: MessageToolState<SearchToolSettings>;
+  bashWorkspace: MessageToolState<BashWorkspaceToolSettings>;
+  analysisWorkspace: MessageToolState<AnalysisWorkspaceToolSettings>;
+  mcpServers: MessageToolState<McpServersToolSettings>;
+  imageGeneration: MessageToolState<ImageGenerationToolSettings>;
 }
 
 export interface MessageToolSettingsInput {
-  search?: SearchToolSettings;
-  bashWorkspace?: BashWorkspaceToolSettings;
-  analysisWorkspace?: AnalysisWorkspaceToolSettingsInput;
-  mcpServers?: McpServersToolSettingsInput;
-  imageGeneration?: ImageGenerationToolSettingsInput;
+  search?: MessageToolStateInput<SearchToolSettings>;
+  bashWorkspace?: MessageToolStateInput<BashWorkspaceToolSettings>;
+  analysisWorkspace?: MessageToolStateInput<AnalysisWorkspaceToolSettingsInput>;
+  mcpServers?: MessageToolStateInput<McpServersToolSettingsInput>;
+  imageGeneration?: MessageToolStateInput<ImageGenerationToolSettingsInput>;
 }
 
 /** Lines shown before collapsing user messages in chat. Use `0` to disable collapsing. */
 export const DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES = 100;
 const DEFAULT_IMAGE_GENERATION_MODEL_ID =
   getImageGenerationToolModels()[0]?.id;
+
+function getDefaultEnabledTools(): MessageToolSettings {
+  return {
+    search: {},
+    bashWorkspace: {},
+    analysisWorkspace: {},
+    mcpServers: {},
+    imageGeneration: {},
+  };
+}
 
 export interface MessageSettings {
   model: string;
@@ -87,18 +99,7 @@ export type MessageSettingsPatch = Partial<Omit<MessageSettings, "tools">> & {
 
 export const DEFAULT_MESSAGE_SETTINGS: MessageSettings = {
   model: DEFAULT_CHAT_MODEL_ID,
-  tools: {
-    search: {},
-    bashWorkspace: {},
-    analysisWorkspace: { syncUploads: true },
-    ...(DEFAULT_IMAGE_GENERATION_MODEL_ID
-      ? {
-          imageGeneration: {
-            modelId: DEFAULT_IMAGE_GENERATION_MODEL_ID,
-          },
-        }
-      : {}),
-  },
+  tools: getDefaultEnabledTools(),
   instructionId: undefined,
   userMessagePreviewMaxLines: DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES,
 };
@@ -107,7 +108,7 @@ function toolsInputForNormalization(
   input: MessageSettingsInput | null | undefined,
 ): MessageToolSettingsInput {
   if (input == null || !Object.prototype.hasOwnProperty.call(input, "tools")) {
-    return { ...DEFAULT_MESSAGE_SETTINGS.tools };
+    return getDefaultEnabledTools();
   }
   return input.tools ?? {};
 }
@@ -186,42 +187,56 @@ function normalizeUserMessagePreviewMaxLines(value: unknown): number {
 function normalizeTools(
   tools: MessageToolSettingsInput | null | undefined,
 ): MessageToolSettings {
-  const normalizedTools: MessageToolSettings = {};
+  const normalizedTools: MessageToolSettings = getDefaultEnabledTools();
+  normalizedTools.search = normalizeSimpleToolState(tools?.search);
+  normalizedTools.bashWorkspace = normalizeSimpleToolState(tools?.bashWorkspace);
+  normalizedTools.analysisWorkspace = normalizeAnalysisWorkspaceToolState(
+    tools?.analysisWorkspace,
+  );
+  normalizedTools.mcpServers = normalizeMcpServersToolState(tools?.mcpServers);
+  normalizedTools.imageGeneration = normalizeImageGenerationToolState(
+    tools?.imageGeneration,
+  );
 
-  if (
-    tools?.search &&
-    typeof tools.search === "object" &&
-    !Array.isArray(tools.search)
-  ) {
-    normalizedTools.search = {};
+  return normalizedTools;
+}
+
+function normalizeSimpleToolState(value: unknown): object | false {
+  if (value === false) {
+    return false;
   }
 
-  if (
-    tools?.bashWorkspace &&
-    typeof tools.bashWorkspace === "object" &&
-    !Array.isArray(tools.bashWorkspace)
-  ) {
-    normalizedTools.bashWorkspace = {};
+  return {};
+}
+
+function normalizeAnalysisWorkspaceToolState(
+  value: MessageToolStateInput<AnalysisWorkspaceToolSettingsInput>,
+): AnalysisWorkspaceToolSettings | false {
+  if (value === false) {
+    return false;
   }
 
-  if (
-    tools?.analysisWorkspace &&
-    typeof tools.analysisWorkspace === "object" &&
-    !Array.isArray(tools.analysisWorkspace)
-  ) {
-    normalizedTools.analysisWorkspace = {
-      syncUploads: tools.analysisWorkspace.syncUploads !== false,
-    };
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if (value.syncUploads === false) {
+      return { syncUploads: false };
+    }
   }
 
-  if (
-    tools?.mcpServers &&
-    typeof tools.mcpServers === "object" &&
-    !Array.isArray(tools.mcpServers)
-  ) {
+  return {};
+}
+
+function normalizeMcpServersToolState(
+  value: MessageToolStateInput<McpServersToolSettingsInput>,
+): McpServersToolSettings | false {
+  if (value === false) {
+    return false;
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const rawServerIds = Array.isArray(value.serverIds) ? value.serverIds : [];
     const serverIds = Array.from(
       new Set(
-        tools.mcpServers.serverIds.filter(
+        rawServerIds.filter(
           (serverId): serverId is string =>
             typeof serverId === "string" && serverId.trim().length > 0,
         ),
@@ -229,37 +244,65 @@ function normalizeTools(
     );
 
     if (serverIds.length > 0) {
-      normalizedTools.mcpServers = { serverIds };
+      return { serverIds };
     }
   }
 
-  if (
-    tools?.imageGeneration &&
-    typeof tools.imageGeneration === "object" &&
-    !Array.isArray(tools.imageGeneration)
-  ) {
+  return {};
+}
+
+function normalizeImageGenerationToolState(
+  value: MessageToolStateInput<ImageGenerationToolSettingsInput>,
+): ImageGenerationToolSettings | false {
+  if (value === false) {
+    return false;
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
     const modelId =
-      typeof tools.imageGeneration.modelId === "string"
-        ? normalizeModelId(tools.imageGeneration.modelId)
-        : undefined;
-
+      typeof value.modelId === "string" ? normalizeModelId(value.modelId) : null;
     if (modelId) {
-      normalizedTools.imageGeneration = { modelId };
+      return { modelId };
     }
   }
 
-  return normalizedTools;
+  return {};
 }
 
 export function isToolEnabled(
   tools: MessageToolSettings,
   toolName: MessageToolName,
 ) {
-  return tools[toolName] !== undefined;
+  return tools[toolName] !== false;
 }
 
 export function getEnabledMessageTools(tools: MessageToolSettings) {
   return MESSAGE_TOOL_NAMES.filter((toolName) =>
     isToolEnabled(tools, toolName),
   );
+}
+
+export function getAnalysisWorkspaceSyncUploads(tools: MessageToolSettings) {
+  const value = tools.analysisWorkspace;
+  return value !== false && value.syncUploads !== false;
+}
+
+export function getImageGenerationToolModelId(tools: MessageToolSettings) {
+  const value = tools.imageGeneration;
+  if (value === false) {
+    return undefined;
+  }
+
+  const explicitModelId =
+    typeof value.modelId === "string" ? normalizeModelId(value.modelId) : null;
+  return explicitModelId ?? DEFAULT_IMAGE_GENERATION_MODEL_ID;
+}
+
+export function getMcpServerIds(tools: MessageToolSettings): string[] {
+  const value = tools.mcpServers;
+  if (value === false) {
+    return [];
+  }
+
+  return value.serverIds ?? [];
 }

--- a/packages/types/src/zod/threads.ts
+++ b/packages/types/src/zod/threads.ts
@@ -12,12 +12,31 @@ const mutationInfo = z.discriminatedUnion("type", [
 ]);
 
 const messageToolsSchema = z.object({
-  search: z.object({}).optional(),
-  bashWorkspace: z.object({}).optional(),
+  search: z.union([z.object({}), z.literal(false)]).optional(),
+  bashWorkspace: z.union([z.object({}), z.literal(false)]).optional(),
   analysisWorkspace: z
-    .object({
-      syncUploads: z.boolean().optional(),
-    })
+    .union([
+      z.object({
+        syncUploads: z.boolean().optional(),
+      }),
+      z.literal(false),
+    ])
+    .optional(),
+  mcpServers: z
+    .union([
+      z.object({
+        serverIds: z.array(z.string()).optional(),
+      }),
+      z.literal(false),
+    ])
+    .optional(),
+  imageGeneration: z
+    .union([
+      z.object({
+        modelId: z.string().optional(),
+      }),
+      z.literal(false),
+    ])
     .optional(),
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refactored tool settings state to use explicit values: enabled as `{}` and disabled as `false`
- updated message settings normalization so unset/undefined/null tool values are treated as enabled and normalized to canonical enabled objects
- added shared helpers for effective tool behavior (`isToolEnabled`, analysis sync upload defaulting, image model fallback, MCP server IDs)
- switched chat input toggles to write `false` when disabling tools and `{}` when enabling
- updated API, Convex function validators, and schema definitions to accept the new tool-state shape (including `false`, and `null` at request/patch boundaries)
- added thread settings self-heal in `useChatSettings` so older thread settings are patched to canonical enabled tool values when loaded
- updated MCP server backend/test logic to use the shared MCP server ID accessor under the new tool-state union

## Testing
- `pnpm --filter @redux/types typecheck` *(fails in this cloud workspace: `tsc: not found`, dependencies are not installed)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78f142e2-658b-4b76-b846-6eb00fff6896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78f142e2-658b-4b76-b846-6eb00fff6896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

