### PR TITLE
Default enable chat tools

### DIFF
--- a/apps/tanstack-start/src/components/chat/input/index.tsx
+++ b/apps/tanstack-start/src/components/chat/input/index.tsx
@@ -15,12 +15,13 @@ import type { ThinkingLevel } from "@redux/shared/models";
 import { api } from "@redux/backend/convex/_generated/api";
 import {
   classifyChatAttachment,
+  DEFAULT_IMAGE_GENERATION_MODEL_ID,
   getChatModelConfig,
   getImageGenerationToolModels,
   resolveModelAttachmentDelivery,
   resolveModelRoute,
 } from "@redux/shared/models";
-import { isToolEnabled } from "@redux/types";
+import { getEnabledToolSettings, isToolEnabled } from "@redux/types";
 import { useSidebar } from "@redux/ui/components/sidebar";
 import { cn } from "@redux/ui/lib/utils";
 
@@ -266,14 +267,19 @@ export function ChatInput({
       })),
     [],
   );
+  const imageGenerationSettings = getEnabledToolSettings(
+    settings.tools,
+    "imageGeneration",
+  );
   const selectedImageGenerationModelId =
-    settings.tools.imageGeneration?.modelId ?? imageGenerationModels[0]?.id;
+    imageGenerationSettings?.modelId ?? DEFAULT_IMAGE_GENERATION_MODEL_ID;
   const isImageGenerationEnabled = isToolEnabled(
     settings.tools,
     "imageGeneration",
   );
   const enabledMcpServerIds = useMemo(
-    () => settings.tools.mcpServers?.serverIds ?? [],
+    () =>
+      getEnabledToolSettings(settings.tools, "mcpServers")?.serverIds ?? [],
     [settings.tools.mcpServers],
   );
   const showErrorBorder = status === "error";
@@ -376,7 +382,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          search: enabled ? {} : undefined,
+          search: enabled ? {} : false,
         },
       });
     },
@@ -387,7 +393,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          analysisWorkspace: enabled ? { syncUploads: true } : undefined,
+          analysisWorkspace: enabled ? { syncUploads: true } : false,
         },
       });
     },
@@ -401,7 +407,7 @@ export function ChatInput({
           imageGeneration:
             enabled && selectedImageGenerationModelId
               ? { modelId: selectedImageGenerationModelId }
-              : undefined,
+              : false,
         },
       });
     },
@@ -423,7 +429,7 @@ export function ChatInput({
     (enabled: boolean) => {
       void onSettingsChange({
         tools: {
-          bashWorkspace: enabled ? {} : undefined,
+          bashWorkspace: enabled ? {} : false,
         },
       });
     },
@@ -489,8 +495,7 @@ export function ChatInput({
 
       void onSettingsChange({
         tools: {
-          mcpServers:
-            nextServerIds.length > 0 ? { serverIds: nextServerIds } : undefined,
+          mcpServers: { serverIds: nextServerIds },
         },
       });
     },

--- a/apps/tanstack-start/src/components/chat/input/index.tsx
+++ b/apps/tanstack-start/src/components/chat/input/index.tsx
@@ -278,8 +278,7 @@ export function ChatInput({
     "imageGeneration",
   );
   const enabledMcpServerIds = useMemo(
-    () =>
-      getEnabledToolSettings(settings.tools, "mcpServers")?.serverIds ?? [],
+    () => getEnabledToolSettings(settings.tools, "mcpServers")?.serverIds ?? [],
     [settings.tools.mcpServers],
   );
   const showErrorBorder = status === "error";
@@ -1174,7 +1173,7 @@ export function ChatInput({
       <AddCreditsDialog
         open={addCreditsOpen}
         onOpenChange={setAddCreditsOpen}
-        billingState={billingState}
+        billingState={billingState ?? undefined}
         triggerContext="out_of_credits"
       />
     </>

--- a/apps/tanstack-start/src/lib/ai/tools/index.ts
+++ b/apps/tanstack-start/src/lib/ai/tools/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import type { BillableToolCall, ToolBillingKey } from "@redux/shared";
 import type { MessageSettings } from "@redux/types";
 import { isImageGenerationToolModel } from "@redux/shared/models";
-import { getEnabledMessageTools } from "@redux/types";
+import { getEnabledMessageTools, getEnabledToolSettings } from "@redux/types";
 
 import { createBashWorkspaceRuntime } from "@/lib/ai/tools/bash-workspace";
 import {
@@ -308,7 +308,8 @@ export async function createToolRuntime(
 
   if (enabledTools.includes("analysisWorkspace")) {
     const uploadsEnabled =
-      settings.tools.analysisWorkspace?.syncUploads !== false;
+      getEnabledToolSettings(settings.tools, "analysisWorkspace")
+        ?.syncUploads !== false;
 
     sandboxRuntime = createSandboxRuntime({
       attachments,
@@ -412,7 +413,10 @@ export async function createToolRuntime(
   }
 
   if (enabledTools.includes("imageGeneration")) {
-    const modelId = settings.tools.imageGeneration?.modelId;
+    const modelId = getEnabledToolSettings(
+      settings.tools,
+      "imageGeneration",
+    )?.modelId;
     if (modelId && generationContext && isImageGenerationToolModel(modelId)) {
       tools.generate_image = instrumentTool(
         tool({

--- a/apps/tanstack-start/src/routes/api/chat/index.ts
+++ b/apps/tanstack-start/src/routes/api/chat/index.ts
@@ -20,7 +20,11 @@ import { z } from "zod";
 import type { ThinkingLevel } from "@redux/shared/models";
 import { api } from "@redux/backend/convex/_generated/api";
 import { getChatModelConfig } from "@redux/shared/models";
-import { isToolEnabled, normalizeMessageSettings } from "@redux/types";
+import {
+  getEnabledToolSettings,
+  isToolEnabled,
+  normalizeMessageSettings,
+} from "@redux/types";
 
 import { env } from "@/env";
 import { createToolRuntime } from "@/lib/ai/tools";
@@ -49,6 +53,9 @@ import { materializeAttachmentsForRoute } from "@/server/chat-attachments/materi
 import { retrieveProjectContext } from "@/server/rag/retrieve";
 import { getPostHogClient } from "@/utils/posthog-server";
 
+const disabledToolSchema = z.literal(false);
+const emptyToolSchema = z.union([z.object({}), disabledToolSchema, z.null()]);
+
 const requestBody = z.object({
   fileIds: z.array(z.string()),
   threadId: z.string(),
@@ -64,25 +71,40 @@ const requestBody = z.object({
     model: z.string(),
     thinkingLevel: z.enum(["instant", "low", "medium", "high"]).optional(),
     instructionId: z.string().optional(),
-    tools: z.object({
-      search: z.object({}).optional(),
-      bashWorkspace: z.object({}).optional(),
-      analysisWorkspace: z
-        .object({
-          syncUploads: z.boolean().optional(),
-        })
-        .optional(),
-      mcpServers: z
-        .object({
-          serverIds: z.array(z.string()),
-        })
-        .optional(),
-      imageGeneration: z
-        .object({
-          modelId: z.string(),
-        })
-        .optional(),
-    }),
+    tools: z
+      .object({
+        search: emptyToolSchema.optional(),
+        bashWorkspace: emptyToolSchema.optional(),
+        analysisWorkspace: z
+          .union([
+            z.object({
+              syncUploads: z.boolean().optional(),
+            }),
+            disabledToolSchema,
+            z.null(),
+          ])
+          .optional(),
+        mcpServers: z
+          .union([
+            z.object({
+              serverIds: z.array(z.string()).optional().nullable(),
+            }),
+            disabledToolSchema,
+            z.null(),
+          ])
+          .optional(),
+        imageGeneration: z
+          .union([
+            z.object({
+              modelId: z.string().optional().nullable(),
+            }),
+            disabledToolSchema,
+            z.null(),
+          ])
+          .optional(),
+      })
+      .optional()
+      .nullable(),
   }),
   model: z.string(),
   id: z.string(),
@@ -468,7 +490,8 @@ export const Route = createFileRoute("/api/chat/")({
           settings.tools,
           "bashWorkspace",
         );
-        const enabledMcpServerIds = settings.tools.mcpServers?.serverIds ?? [];
+        const enabledMcpServerIds =
+          getEnabledToolSettings(settings.tools, "mcpServers")?.serverIds ?? [];
         console.log("Received request:", {
           threadId,
           assistantMessageId,

--- a/packages/backend/convex/functions/defaultMessageSettings.test.ts
+++ b/packages/backend/convex/functions/defaultMessageSettings.test.ts
@@ -1,0 +1,86 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_IMAGE_GENERATION_MODEL_ID } from "@redux/shared/models";
+import { getEnabledToolSettings } from "@redux/types";
+
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+const USER_ID = "user-1";
+
+function authedTest(userId = USER_ID) {
+  return convexTest(schema, modules).withIdentity({ subject: userId });
+}
+
+describe("functions/defaultMessageSettings", () => {
+  it("normalizes missing tools to enabled defaults and writes them back", async () => {
+    const t = authedTest();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("defaultMessageSettings", {
+        userId: USER_ID,
+        settings: { model: "openai/gpt-5", tools: {} },
+        updatedAt: 1,
+      });
+    });
+
+    const settings = await t.mutation(
+      api.functions.defaultMessageSettings.getOrCreate,
+      {},
+    );
+
+    expect(settings.tools.search).toEqual({});
+    expect(settings.tools.bashWorkspace).toEqual({});
+    expect(settings.tools.analysisWorkspace).toEqual({ syncUploads: true });
+    expect(settings.tools.mcpServers).toEqual({ serverIds: [] });
+    expect(settings.tools.imageGeneration).toEqual({
+      modelId: DEFAULT_IMAGE_GENERATION_MODEL_ID,
+    });
+
+    const stored = await t.run(async (ctx) =>
+      ctx.db
+        .query("defaultMessageSettings")
+        .withIndex("by_userId", (q) => q.eq("userId", USER_ID))
+        .first(),
+    );
+
+    expect(stored?.settings.tools).toEqual(settings.tools);
+  });
+
+  it("uses false for disabled tools and null to restore enabled defaults", async () => {
+    const t = authedTest();
+
+    const disabled = await t.mutation(
+      api.functions.defaultMessageSettings.update,
+      {
+        patch: {
+          tools: {
+            search: false,
+            imageGeneration: false,
+          },
+        },
+      },
+    );
+
+    expect(disabled.tools.search).toBe(false);
+    expect(disabled.tools.imageGeneration).toBe(false);
+
+    const restored = await t.mutation(
+      api.functions.defaultMessageSettings.update,
+      {
+        patch: {
+          tools: {
+            imageGeneration: null,
+          },
+        },
+      },
+    );
+
+    expect(restored.tools.search).toBe(false);
+    expect(
+      getEnabledToolSettings(restored.tools, "imageGeneration")?.modelId,
+    ).toBe(DEFAULT_IMAGE_GENERATION_MODEL_ID);
+  });
+});

--- a/packages/backend/convex/functions/defaultMessageSettings.test.ts
+++ b/packages/backend/convex/functions/defaultMessageSettings.test.ts
@@ -15,7 +15,7 @@ function authedTest(userId = USER_ID) {
 }
 
 describe("functions/defaultMessageSettings", () => {
-  it("normalizes missing tools to enabled defaults and writes them back", async () => {
+  it("preserves legacy disabled tools while defaulting new tools on", async () => {
     const t = authedTest();
 
     await t.run(async (ctx) => {
@@ -31,9 +31,9 @@ describe("functions/defaultMessageSettings", () => {
       {},
     );
 
-    expect(settings.tools.search).toEqual({});
-    expect(settings.tools.bashWorkspace).toEqual({});
-    expect(settings.tools.analysisWorkspace).toEqual({ syncUploads: true });
+    expect(settings.tools.search).toBe(false);
+    expect(settings.tools.bashWorkspace).toBe(false);
+    expect(settings.tools.analysisWorkspace).toBe(false);
     expect(settings.tools.mcpServers).toEqual({ serverIds: [] });
     expect(settings.tools.imageGeneration).toEqual({
       modelId: DEFAULT_IMAGE_GENERATION_MODEL_ID,

--- a/packages/backend/convex/functions/defaultMessageSettings.ts
+++ b/packages/backend/convex/functions/defaultMessageSettings.ts
@@ -11,6 +11,42 @@ const thinkingLevelValidator = v.union(
   v.literal("medium"),
   v.literal("high"),
 );
+const emptyToolPatchValidator = v.union(
+  v.object({}),
+  v.literal(false),
+  v.null(),
+);
+const toolPatchValidator = v.object({
+  search: v.optional(emptyToolPatchValidator),
+  bashWorkspace: v.optional(emptyToolPatchValidator),
+  analysisWorkspace: v.optional(
+    v.union(
+      v.object({
+        syncUploads: v.optional(v.boolean()),
+      }),
+      v.literal(false),
+      v.null(),
+    ),
+  ),
+  mcpServers: v.optional(
+    v.union(
+      v.object({
+        serverIds: v.optional(v.union(v.array(v.string()), v.null())),
+      }),
+      v.literal(false),
+      v.null(),
+    ),
+  ),
+  imageGeneration: v.optional(
+    v.union(
+      v.object({
+        modelId: v.optional(v.union(v.string(), v.null())),
+      }),
+      v.literal(false),
+      v.null(),
+    ),
+  ),
+});
 
 export const getOrCreate = mutation({
   args: {},
@@ -60,27 +96,7 @@ export const update = mutation({
       clearInstructionId: v.optional(v.boolean()),
       model: v.optional(v.string()),
       thinkingLevel: v.optional(thinkingLevelValidator),
-      tools: v.optional(
-        v.object({
-          search: v.optional(v.object({})),
-          bashWorkspace: v.optional(v.object({})),
-          analysisWorkspace: v.optional(
-            v.object({
-              syncUploads: v.optional(v.boolean()),
-            }),
-          ),
-          mcpServers: v.optional(
-            v.object({
-              serverIds: v.array(v.string()),
-            }),
-          ),
-          imageGeneration: v.optional(
-            v.object({
-              modelId: v.string(),
-            }),
-          ),
-        }),
-      ),
+      tools: v.optional(v.union(toolPatchValidator, v.null())),
     }),
   },
   handler: async (ctx, args) => {

--- a/packages/backend/convex/functions/defaultMessageSettings.ts
+++ b/packages/backend/convex/functions/defaultMessageSettings.ts
@@ -1,6 +1,10 @@
 import { v } from "convex/values";
 
-import { mergeMessageSettings, normalizeMessageSettings } from "@redux/types";
+import {
+  mergePersistedMessageSettings,
+  normalizeMessageSettings,
+  normalizePersistedMessageSettings,
+} from "@redux/types";
 
 import { mutation } from "./index";
 import { normalizeInstructionIdForUser } from "./instructions";
@@ -57,7 +61,9 @@ export const getOrCreate = mutation({
       .first();
 
     if (existing) {
-      const normalizedSettings = normalizeMessageSettings(existing.settings);
+      const normalizedSettings = normalizePersistedMessageSettings(
+        existing.settings,
+      );
       normalizedSettings.instructionId = await normalizeInstructionIdForUser(
         ctx,
         ctx.userId,
@@ -106,7 +112,7 @@ export const update = mutation({
       .first();
 
     const { clearInstructionId, ...settingsPatch } = args.patch;
-    const mergedSettings = mergeMessageSettings(
+    const mergedSettings = mergePersistedMessageSettings(
       existing?.settings,
       settingsPatch,
     );

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -1,6 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getEnabledToolSettings } from "@redux/types";
+
 import { api } from "../_generated/api";
 import schema from "../schema";
 import { modules } from "../test.setup";
@@ -124,9 +126,10 @@ describe("functions/mcpServers", () => {
         .first();
     });
 
-    expect(defaultSettings?.settings.tools.mcpServers?.serverIds).toEqual([
-      mcpServerId,
-    ]);
+    expect(
+      getEnabledToolSettings(defaultSettings?.settings.tools, "mcpServers")
+        ?.serverIds,
+    ).toEqual([mcpServerId]);
   });
 
   it("removes deleted server ids from default settings and thread settings", async () => {
@@ -186,10 +189,14 @@ describe("functions/mcpServers", () => {
     });
 
     expect(
-      stored.defaultSettings?.settings.tools.mcpServers?.serverIds,
+      getEnabledToolSettings(
+        stored.defaultSettings?.settings.tools,
+        "mcpServers",
+      )?.serverIds,
     ).toEqual([retainedServerId]);
-    expect(stored.thread?.settings.tools.mcpServers?.serverIds).toEqual([
-      retainedServerId,
-    ]);
+    expect(
+      getEnabledToolSettings(stored.thread?.settings.tools, "mcpServers")
+        ?.serverIds,
+    ).toEqual([retainedServerId]);
   });
 });

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -199,4 +199,26 @@ describe("functions/mcpServers", () => {
         ?.serverIds,
     ).toEqual([retainedServerId]);
   });
+
+  it("stores an empty MCP server config when deleting the last enabled server", async () => {
+    const t = authedTest();
+    const { mcpServerId } = await t.mutation(api.functions.mcpServers.create, {
+      name: "MCP",
+      url: "https://example.com/mcp",
+    });
+
+    await t.mutation(api.functions.mcpServers.remove, { mcpServerId });
+
+    const defaultSettings = await t.run(async (ctx) =>
+      ctx.db
+        .query("defaultMessageSettings")
+        .withIndex("by_userId", (q) => q.eq("userId", USER_ID))
+        .first(),
+    );
+
+    expect(
+      getEnabledToolSettings(defaultSettings?.settings.tools, "mcpServers")
+        ?.serverIds,
+    ).toEqual([]);
+  });
 });

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -1,7 +1,10 @@
 import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
-import { getEnabledToolSettings, mergeMessageSettings } from "@redux/types";
+import {
+  getEnabledToolSettings,
+  mergePersistedMessageSettings,
+} from "@redux/types";
 
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { mutation, query } from "./index";
@@ -245,10 +248,10 @@ function stripDeletedServerIdFromSettings<
     return undefined;
   }
 
-  return mergeMessageSettings(doc.settings, {
+  return mergePersistedMessageSettings(doc.settings, {
     tools: {
       ...doc.settings.tools,
-      mcpServers: nextIds.length > 0 ? { serverIds: nextIds } : undefined,
+      mcpServers: { serverIds: nextIds },
     },
   });
 }
@@ -266,7 +269,7 @@ async function addServerIdToDefaultSettings(
     ? (getEnabledToolSettings(existing.settings.tools, "mcpServers")
         ?.serverIds ?? [])
     : [];
-  const settings = mergeMessageSettings(existing?.settings, {
+  const settings = mergePersistedMessageSettings(existing?.settings, {
     tools: {
       mcpServers: {
         serverIds: [...currentServerIds, mcpServerId],

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -1,7 +1,7 @@
 import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
-import { mergeMessageSettings } from "@redux/types";
+import { getEnabledToolSettings, mergeMessageSettings } from "@redux/types";
 
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { mutation, query } from "./index";
@@ -237,7 +237,8 @@ async function setMcpServersEnabled(
 function stripDeletedServerIdFromSettings<
   T extends Doc<"defaultMessageSettings"> | Doc<"threads">,
 >(doc: T, mcpServerId: string) {
-  const currentIds = doc.settings.tools.mcpServers?.serverIds ?? [];
+  const currentIds =
+    getEnabledToolSettings(doc.settings.tools, "mcpServers")?.serverIds ?? [];
   const nextIds = currentIds.filter((serverId) => serverId !== mcpServerId);
 
   if (nextIds.length === currentIds.length) {
@@ -261,7 +262,10 @@ async function addServerIdToDefaultSettings(
     .query("defaultMessageSettings")
     .withIndex("by_userId", (q) => q.eq("userId", ctx.userId))
     .first();
-  const currentServerIds = existing?.settings.tools.mcpServers?.serverIds ?? [];
+  const currentServerIds = existing
+    ? (getEnabledToolSettings(existing.settings.tools, "mcpServers")
+        ?.serverIds ?? [])
+    : [];
   const settings = mergeMessageSettings(existing?.settings, {
     tools: {
       mcpServers: {

--- a/packages/backend/convex/functions/threads.ts
+++ b/packages/backend/convex/functions/threads.ts
@@ -6,7 +6,11 @@ import { Buffer } from "buffer/";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
-import { mergeMessageSettings, normalizeMessageSettings } from "@redux/types";
+import {
+  mergePersistedMessageSettings,
+  normalizeMessageSettings,
+  normalizePersistedMessageSettings,
+} from "@redux/types";
 
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
@@ -426,7 +430,7 @@ export const getThread = query({
 
     return {
       ...thread,
-      settings: normalizeMessageSettings(thread.settings),
+      settings: normalizePersistedMessageSettings(thread.settings),
     };
   },
 });
@@ -1323,7 +1327,10 @@ export const updateThreadSettings = mutation({
     }
 
     const { clearInstructionId, ...settingsPatch } = args.patch;
-    const mergedSettings = mergeMessageSettings(thread.settings, settingsPatch);
+    const mergedSettings = mergePersistedMessageSettings(
+      thread.settings,
+      settingsPatch,
+    );
     mergedSettings.instructionId = await normalizeInstructionIdForUser(
       ctx,
       ctx.userId,

--- a/packages/backend/convex/functions/threads.ts
+++ b/packages/backend/convex/functions/threads.ts
@@ -53,6 +53,12 @@ const thinkingLevelValidator = v.union(
   v.literal("medium"),
   v.literal("high"),
 );
+const emptyStoredToolValidator = v.union(v.object({}), v.literal(false));
+const emptyToolPatchValidator = v.union(
+  v.object({}),
+  v.literal(false),
+  v.null(),
+);
 
 const messageSettingsValidator = v.object({
   model: v.string(),
@@ -60,24 +66,65 @@ const messageSettingsValidator = v.object({
   instructionId: v.optional(v.string()),
   userMessagePreviewMaxLines: v.optional(v.number()),
   tools: v.object({
-    search: v.optional(v.object({})),
-    bashWorkspace: v.optional(v.object({})),
+    search: v.optional(emptyStoredToolValidator),
+    bashWorkspace: v.optional(emptyStoredToolValidator),
     analysisWorkspace: v.optional(
+      v.union(
+        v.object({
+          syncUploads: v.optional(v.boolean()),
+        }),
+        v.literal(false),
+      ),
+    ),
+    mcpServers: v.optional(
+      v.union(
+        v.object({
+          serverIds: v.array(v.string()),
+        }),
+        v.literal(false),
+      ),
+    ),
+    imageGeneration: v.optional(
+      v.union(
+        v.object({
+          modelId: v.string(),
+        }),
+        v.literal(false),
+      ),
+    ),
+  }),
+});
+
+const messageSettingsToolPatchValidator = v.object({
+  search: v.optional(emptyToolPatchValidator),
+  bashWorkspace: v.optional(emptyToolPatchValidator),
+  analysisWorkspace: v.optional(
+    v.union(
       v.object({
         syncUploads: v.optional(v.boolean()),
       }),
+      v.literal(false),
+      v.null(),
     ),
-    mcpServers: v.optional(
+  ),
+  mcpServers: v.optional(
+    v.union(
       v.object({
-        serverIds: v.array(v.string()),
+        serverIds: v.optional(v.union(v.array(v.string()), v.null())),
       }),
+      v.literal(false),
+      v.null(),
     ),
-    imageGeneration: v.optional(
+  ),
+  imageGeneration: v.optional(
+    v.union(
       v.object({
-        modelId: v.string(),
+        modelId: v.optional(v.union(v.string(), v.null())),
       }),
+      v.literal(false),
+      v.null(),
     ),
-  }),
+  ),
 });
 
 async function getThreadForUser(
@@ -1262,27 +1309,7 @@ export const updateThreadSettings = mutation({
       clearInstructionId: v.optional(v.boolean()),
       model: v.optional(v.string()),
       thinkingLevel: v.optional(thinkingLevelValidator),
-      tools: v.optional(
-        v.object({
-          search: v.optional(v.object({})),
-          bashWorkspace: v.optional(v.object({})),
-          analysisWorkspace: v.optional(
-            v.object({
-              syncUploads: v.optional(v.boolean()),
-            }),
-          ),
-          mcpServers: v.optional(
-            v.object({
-              serverIds: v.array(v.string()),
-            }),
-          ),
-          imageGeneration: v.optional(
-            v.object({
-              modelId: v.string(),
-            }),
-          ),
-        }),
-      ),
+      tools: v.optional(v.union(messageSettingsToolPatchValidator, v.null())),
     }),
   },
   handler: async (ctx, args) => {

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -97,23 +97,33 @@ const threadShareSettings = v.object({
   autoUpdate: v.boolean(),
 });
 
+const emptyTool = v.union(v.object({}), v.literal(false));
 const messageTools = v.object({
-  search: v.optional(v.object({})),
-  bashWorkspace: v.optional(v.object({})),
+  search: v.optional(emptyTool),
+  bashWorkspace: v.optional(emptyTool),
   analysisWorkspace: v.optional(
-    v.object({
-      syncUploads: v.optional(v.boolean()),
-    }),
+    v.union(
+      v.object({
+        syncUploads: v.optional(v.boolean()),
+      }),
+      v.literal(false),
+    ),
   ),
   mcpServers: v.optional(
-    v.object({
-      serverIds: v.array(v.string()),
-    }),
+    v.union(
+      v.object({
+        serverIds: v.array(v.string()),
+      }),
+      v.literal(false),
+    ),
   ),
   imageGeneration: v.optional(
-    v.object({
-      modelId: v.string(),
-    }),
+    v.union(
+      v.object({
+        modelId: v.string(),
+      }),
+      v.literal(false),
+    ),
   ),
 });
 

--- a/packages/shared/src/models/defaults.ts
+++ b/packages/shared/src/models/defaults.ts
@@ -1,6 +1,8 @@
 import type { CanonicalModelId } from "./types";
 
 export const DEFAULT_CHAT_MODEL_ID: CanonicalModelId = "moonshot/kimi-k2.5";
+export const DEFAULT_IMAGE_GENERATION_MODEL_ID: CanonicalModelId =
+  "google/nano-banana-2";
 
 export const defaultFavorites = [
   "moonshot/kimi-k2.5",

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -5,7 +5,11 @@ export {
   NEW_MODEL_RECENCY_DAYS,
   parseModelReleasedAtMs,
 } from "./release-date";
-export { DEFAULT_CHAT_MODEL_ID, defaultFavorites } from "./defaults";
+export {
+  DEFAULT_CHAT_MODEL_ID,
+  DEFAULT_IMAGE_GENERATION_MODEL_ID,
+  defaultFavorites,
+} from "./defaults";
 export { PROVIDERS } from "./curated";
 export { classifyChatAttachment } from "./route-behavior";
 export {

--- a/packages/types/src/chat/message-settings.ts
+++ b/packages/types/src/chat/message-settings.ts
@@ -1,5 +1,10 @@
 import type { ThinkingLevel } from "@redux/shared/models";
-import { DEFAULT_CHAT_MODEL_ID, normalizeModelId } from "@redux/shared/models";
+import {
+  DEFAULT_CHAT_MODEL_ID,
+  DEFAULT_IMAGE_GENERATION_MODEL_ID,
+  isImageGenerationToolModel,
+  normalizeModelId,
+} from "@redux/shared/models";
 
 export const MESSAGE_TOOL_NAMES = [
   "search",
@@ -11,9 +16,9 @@ export const MESSAGE_TOOL_NAMES = [
 
 export type MessageToolName = (typeof MESSAGE_TOOL_NAMES)[number];
 
-export type SearchToolSettings = object;
+export type SearchToolSettings = Record<string, never>;
 
-export type BashWorkspaceToolSettings = object;
+export type BashWorkspaceToolSettings = Record<string, never>;
 
 export interface AnalysisWorkspaceToolSettings {
   syncUploads: boolean;
@@ -28,7 +33,7 @@ export interface McpServersToolSettings {
 }
 
 export interface McpServersToolSettingsInput {
-  serverIds: string[];
+  serverIds?: string[] | null;
 }
 
 export interface ImageGenerationToolSettings {
@@ -36,24 +41,39 @@ export interface ImageGenerationToolSettings {
 }
 
 export interface ImageGenerationToolSettingsInput {
-  modelId: string;
+  modelId?: string | null;
 }
 
-export interface MessageToolSettings {
-  search?: SearchToolSettings;
-  bashWorkspace?: BashWorkspaceToolSettings;
-  analysisWorkspace?: AnalysisWorkspaceToolSettings;
-  mcpServers?: McpServersToolSettings;
-  imageGeneration?: ImageGenerationToolSettings;
+export interface MessageToolSettingsByName {
+  search: SearchToolSettings;
+  bashWorkspace: BashWorkspaceToolSettings;
+  analysisWorkspace: AnalysisWorkspaceToolSettings;
+  mcpServers: McpServersToolSettings;
+  imageGeneration: ImageGenerationToolSettings;
 }
 
-export interface MessageToolSettingsInput {
-  search?: SearchToolSettings;
-  bashWorkspace?: BashWorkspaceToolSettings;
-  analysisWorkspace?: AnalysisWorkspaceToolSettingsInput;
-  mcpServers?: McpServersToolSettingsInput;
-  imageGeneration?: ImageGenerationToolSettingsInput;
+export interface MessageToolSettingsInputByName {
+  search: SearchToolSettings;
+  bashWorkspace: BashWorkspaceToolSettings;
+  analysisWorkspace: AnalysisWorkspaceToolSettingsInput;
+  mcpServers: McpServersToolSettingsInput;
+  imageGeneration: ImageGenerationToolSettingsInput;
 }
+
+export type MessageToolSetting<T> = T | false;
+
+export type MessageToolSettings = {
+  [ToolName in MessageToolName]: MessageToolSetting<
+    MessageToolSettingsByName[ToolName]
+  >;
+};
+
+export type MessageToolSettingsInput = Partial<{
+  [ToolName in MessageToolName]:
+    | MessageToolSettingsInputByName[ToolName]
+    | false
+    | null;
+}>;
 
 /** Lines shown before collapsing user messages in chat. Use `0` to disable collapsing. */
 export const DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES = 100;
@@ -72,11 +92,11 @@ export interface MessageSettingsInput extends Omit<
   Partial<MessageSettings>,
   "tools"
 > {
-  tools?: MessageToolSettingsInput;
+  tools?: MessageToolSettingsInput | null;
 }
 
 export type MessageSettingsPatch = Partial<Omit<MessageSettings, "tools">> & {
-  tools?: MessageToolSettingsInput;
+  tools?: MessageToolSettingsInput | null;
 };
 
 export const DEFAULT_MESSAGE_SETTINGS: MessageSettings = {
@@ -85,18 +105,15 @@ export const DEFAULT_MESSAGE_SETTINGS: MessageSettings = {
     search: {},
     bashWorkspace: {},
     analysisWorkspace: { syncUploads: true },
+    mcpServers: { serverIds: [] },
+    imageGeneration: { modelId: DEFAULT_IMAGE_GENERATION_MODEL_ID },
   },
   instructionId: undefined,
   userMessagePreviewMaxLines: DEFAULT_USER_MESSAGE_PREVIEW_MAX_LINES,
 };
 
-function toolsInputForNormalization(
-  input: MessageSettingsInput | null | undefined,
-): MessageToolSettingsInput {
-  if (input == null || !Object.prototype.hasOwnProperty.call(input, "tools")) {
-    return { ...DEFAULT_MESSAGE_SETTINGS.tools };
-  }
-  return input.tools ?? {};
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export function normalizeMessageSettings(
@@ -113,7 +130,7 @@ export function normalizeMessageSettings(
     ...rest,
     model: normalizedModel,
     thinkingLevel: normalizeThinkingLevel(rest.thinkingLevel),
-    tools: normalizeTools(toolsInputForNormalization(input)),
+    tools: normalizeTools(input?.tools),
     userMessagePreviewMaxLines: normalizeUserMessagePreviewMaxLines(
       rest.userMessagePreviewMaxLines,
     ),
@@ -135,10 +152,14 @@ export function mergeMessageSettings(
     ...patch,
     tools:
       patch.tools !== undefined
-        ? normalizeTools({
-            ...normalizedBase.tools,
-            ...patch.tools,
-          })
+        ? normalizeTools(
+            patch.tools === null
+              ? null
+              : {
+                  ...normalizedBase.tools,
+                  ...patch.tools,
+                },
+          )
         : normalizedBase.tools,
   });
 }
@@ -170,83 +191,91 @@ function normalizeUserMessagePreviewMaxLines(value: unknown): number {
   return Math.min(50_000, Math.max(1, rounded));
 }
 
-function normalizeTools(
-  tools: MessageToolSettingsInput | null | undefined,
+export function normalizeTools(
+  tools: MessageToolSettings | MessageToolSettingsInput | null | undefined,
 ): MessageToolSettings {
-  const normalizedTools: MessageToolSettings = {};
-
-  if (
-    tools?.search &&
-    typeof tools.search === "object" &&
-    !Array.isArray(tools.search)
-  ) {
-    normalizedTools.search = {};
-  }
-
-  if (
-    tools?.bashWorkspace &&
-    typeof tools.bashWorkspace === "object" &&
-    !Array.isArray(tools.bashWorkspace)
-  ) {
-    normalizedTools.bashWorkspace = {};
-  }
-
-  if (
-    tools?.analysisWorkspace &&
-    typeof tools.analysisWorkspace === "object" &&
-    !Array.isArray(tools.analysisWorkspace)
-  ) {
-    normalizedTools.analysisWorkspace = {
-      syncUploads: tools.analysisWorkspace.syncUploads !== false,
-    };
-  }
-
-  if (
-    tools?.mcpServers &&
-    typeof tools.mcpServers === "object" &&
-    !Array.isArray(tools.mcpServers)
-  ) {
-    const serverIds = Array.from(
-      new Set(
-        tools.mcpServers.serverIds.filter(
-          (serverId): serverId is string =>
-            typeof serverId === "string" && serverId.trim().length > 0,
-        ),
-      ),
-    );
-
-    if (serverIds.length > 0) {
-      normalizedTools.mcpServers = { serverIds };
-    }
-  }
-
-  if (
-    tools?.imageGeneration &&
-    typeof tools.imageGeneration === "object" &&
-    !Array.isArray(tools.imageGeneration)
-  ) {
-    const modelId =
-      typeof tools.imageGeneration.modelId === "string"
-        ? normalizeModelId(tools.imageGeneration.modelId)
-        : undefined;
-
-    if (modelId) {
-      normalizedTools.imageGeneration = { modelId };
-    }
-  }
-
-  return normalizedTools;
+  return {
+    search: tools?.search === false ? false : {},
+    bashWorkspace: tools?.bashWorkspace === false ? false : {},
+    analysisWorkspace:
+      tools?.analysisWorkspace === false
+        ? false
+        : {
+            syncUploads:
+              isRecord(tools?.analysisWorkspace) &&
+              tools.analysisWorkspace.syncUploads === false
+                ? false
+                : true,
+          },
+    mcpServers:
+      tools?.mcpServers === false
+        ? false
+        : {
+            serverIds: normalizeMcpServerIds(
+              isRecord(tools?.mcpServers)
+                ? tools.mcpServers.serverIds
+                : undefined,
+            ),
+          },
+    imageGeneration:
+      tools?.imageGeneration === false
+        ? false
+        : {
+            modelId: normalizeImageGenerationModelId(
+              isRecord(tools?.imageGeneration)
+                ? tools.imageGeneration.modelId
+                : undefined,
+            ),
+          },
+  };
 }
 
 export function isToolEnabled(
-  tools: MessageToolSettings,
+  tools: MessageToolSettings | MessageToolSettingsInput | null | undefined,
   toolName: MessageToolName,
 ) {
-  return tools[toolName] !== undefined;
+  return tools?.[toolName] !== false;
 }
 
 export function getEnabledMessageTools(tools: MessageToolSettings) {
   return MESSAGE_TOOL_NAMES.filter((toolName) =>
     isToolEnabled(tools, toolName),
   );
+}
+
+export function getEnabledToolSettings<ToolName extends MessageToolName>(
+  tools: MessageToolSettings | MessageToolSettingsInput | null | undefined,
+  toolName: ToolName,
+): MessageToolSettingsByName[ToolName] | undefined {
+  const value = normalizeTools(tools)[toolName];
+
+  if (value === false) {
+    return undefined;
+  }
+
+  return value as MessageToolSettingsByName[ToolName];
+}
+
+function normalizeMcpServerIds(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value.filter(
+        (serverId): serverId is string =>
+          typeof serverId === "string" && serverId.trim().length > 0,
+      ),
+    ),
+  );
+}
+
+function normalizeImageGenerationModelId(value: unknown) {
+  const modelId =
+    typeof value === "string" ? normalizeModelId(value) : undefined;
+
+  return modelId && isImageGenerationToolModel(modelId)
+    ? modelId
+    : DEFAULT_IMAGE_GENERATION_MODEL_ID;
 }

--- a/packages/types/src/chat/message-settings.ts
+++ b/packages/types/src/chat/message-settings.ts
@@ -13,6 +13,11 @@ export const MESSAGE_TOOL_NAMES = [
   "mcpServers",
   "imageGeneration",
 ] as const;
+const LEGACY_ABSENT_MEANS_DISABLED_TOOL_NAMES = [
+  "search",
+  "bashWorkspace",
+  "analysisWorkspace",
+] as const;
 
 export type MessageToolName = (typeof MESSAGE_TOOL_NAMES)[number];
 
@@ -116,8 +121,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function hasOwnKey(value: Record<string, unknown>, key: string) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
 export function normalizeMessageSettings(
   input: MessageSettingsInput | null | undefined,
+): MessageSettings {
+  return normalizeMessageSettingsWithTools(input, normalizeTools(input?.tools));
+}
+
+export function normalizePersistedMessageSettings(
+  input: MessageSettingsInput | null | undefined,
+): MessageSettings {
+  return normalizeMessageSettingsWithTools(
+    input,
+    normalizePersistedTools(input?.tools),
+  );
+}
+
+function normalizeMessageSettingsWithTools(
+  input: MessageSettingsInput | null | undefined,
+  tools: MessageToolSettings,
 ): MessageSettings {
   const rest = input ?? {};
   const normalizedModel =
@@ -130,7 +155,7 @@ export function normalizeMessageSettings(
     ...rest,
     model: normalizedModel,
     thinkingLevel: normalizeThinkingLevel(rest.thinkingLevel),
-    tools: normalizeTools(input?.tools),
+    tools,
     userMessagePreviewMaxLines: normalizeUserMessagePreviewMaxLines(
       rest.userMessagePreviewMaxLines,
     ),
@@ -141,8 +166,26 @@ export function mergeMessageSettings(
   base: MessageSettingsInput | null | undefined,
   patch: MessageSettingsPatch | null | undefined,
 ): MessageSettings {
-  const normalizedBase = normalizeMessageSettings(base);
+  return mergeMessageSettingsWithNormalizedBase(
+    normalizeMessageSettings(base),
+    patch,
+  );
+}
 
+export function mergePersistedMessageSettings(
+  base: MessageSettingsInput | null | undefined,
+  patch: MessageSettingsPatch | null | undefined,
+): MessageSettings {
+  return mergeMessageSettingsWithNormalizedBase(
+    normalizePersistedMessageSettings(base),
+    patch,
+  );
+}
+
+function mergeMessageSettingsWithNormalizedBase(
+  normalizedBase: MessageSettings,
+  patch: MessageSettingsPatch | null | undefined,
+): MessageSettings {
   if (!patch) {
     return normalizedBase;
   }
@@ -228,6 +271,24 @@ export function normalizeTools(
             ),
           },
   };
+}
+
+export function normalizePersistedTools(
+  tools: MessageToolSettings | MessageToolSettingsInput | null | undefined,
+): MessageToolSettings {
+  const normalizedTools = normalizeTools(tools);
+
+  if (!isRecord(tools)) {
+    return normalizedTools;
+  }
+
+  for (const toolName of LEGACY_ABSENT_MEANS_DISABLED_TOOL_NAMES) {
+    if (!hasOwnKey(tools, toolName)) {
+      normalizedTools[toolName] = false;
+    }
+  }
+
+  return normalizedTools;
 }
 
 export function isToolEnabled(

--- a/packages/types/src/zod/threads.ts
+++ b/packages/types/src/zod/threads.ts
@@ -12,12 +12,31 @@ const mutationInfo = z.discriminatedUnion("type", [
 ]);
 
 const messageToolsSchema = z.object({
-  search: z.object({}).optional(),
-  bashWorkspace: z.object({}).optional(),
+  search: z.union([z.object({}), z.literal(false)]).optional(),
+  bashWorkspace: z.union([z.object({}), z.literal(false)]).optional(),
   analysisWorkspace: z
-    .object({
-      syncUploads: z.boolean().optional(),
-    })
+    .union([
+      z.object({
+        syncUploads: z.boolean().optional(),
+      }),
+      z.literal(false),
+    ])
+    .optional(),
+  mcpServers: z
+    .union([
+      z.object({
+        serverIds: z.array(z.string()),
+      }),
+      z.literal(false),
+    ])
+    .optional(),
+  imageGeneration: z
+    .union([
+      z.object({
+        modelId: z.string(),
+      }),
+      z.literal(false),
+    ])
     .optional(),
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor chat tool settings so `false` is the disabled state and missing/null tool values normalize to enabled configs.
- Preserve legacy persisted disabled Search/Bash/Analysis settings by using legacy-aware normalization at backend persistence boundaries.
- Enable all default tool configs, including MCP server settings and image generation.
- Add a default image generation model constant set to `google/nano-banana-2` and use it for image tool defaults.
- Update client/server validators and tool runtime reads for the new config shape.
- Persist an explicit empty MCP server config when deleting the last enabled server ID.

## Testing
- `pnpm -F @redux/backend test -- defaultMessageSettings mcpServers`
- `pnpm -F @redux/types typecheck`
- `pnpm -F @redux/backend typecheck`
- `pnpm -F @redux/tanstack-start typecheck`

## Notes
- Commands were run under Node v22.22.3; the repo declares Node `^24.0.0`, so pnpm emitted engine warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7472bc40-c28c-4359-95e6-7b9f0a8c03f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7472bc40-c28c-4359-95e6-7b9f0a8c03f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool configs now record explicit disabled states (false) instead of clearing/omitting values.
  * MCP server lists persist empty arrays instead of deleting the config.

* **Improvements**
  * Added a default image-generation model and improved defaults handling.
  * More permissive, consistent validation and normalization for tool settings and API inputs.

* **Tests**
  * Added/updated tests to verify normalization, defaults, and MCP server behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Badbird5907/redux-chat/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->