### PR TITLE
Add earliest-of-both expiry option for gifted credit promotions

### DIFF
--- a/apps/tanstack-start/src/components/admin/promotion-form-fields.tsx
+++ b/apps/tanstack-start/src/components/admin/promotion-form-fields.tsx
@@ -98,6 +98,7 @@ export function AppCreditsConfigFields({
       <div className="grid gap-2">
         <Label>Eligible plans</Label>
         <RadioGroup
+          orientation="horizontal"
           value={planEligibilityMode}
           onValueChange={(next) => {
             const value = typeof next === "string" ? next : "";
@@ -149,21 +150,23 @@ export function AppCreditsConfigFields({
       <div className="grid gap-2">
         <Label>Credit expiration</Label>
         <RadioGroup
+          orientation="horizontal"
           value={expiryMode}
           onValueChange={(next) => {
             const value = typeof next === "string" ? next : "";
             if (
               value === "never" ||
               value === "after_days" ||
-              value === "fixed_date"
+              value === "fixed_date" ||
+              value === "earliest"
             ) {
               setExpiryMode(value);
             }
           }}
           aria-label="Gifted credit expiration policy"
         >
-          <Label className={perUserRadioTileClass}>
-            <RadioGroupItem value="never" />
+          <Label className={`${perUserRadioTileClass} relative`}>
+            <RadioGroupItem value="never" className="absolute opacity-0" />
             <span className="min-w-0 flex-1 leading-snug">
               <span className="block text-sm font-medium">Never expire</span>
               <span className="text-muted-foreground block text-xs font-normal">
@@ -171,8 +174,11 @@ export function AppCreditsConfigFields({
               </span>
             </span>
           </Label>
-          <Label className={perUserRadioTileClass}>
-            <RadioGroupItem value="after_days" />
+          <Label className={`${perUserRadioTileClass} relative`}>
+            <RadioGroupItem
+              value="after_days"
+              className="absolute opacity-0"
+            />
             <span className="min-w-0 flex-1 leading-snug">
               <span className="block text-sm font-medium">
                 Expire after days
@@ -182,8 +188,11 @@ export function AppCreditsConfigFields({
               </span>
             </span>
           </Label>
-          <Label className={perUserRadioTileClass}>
-            <RadioGroupItem value="fixed_date" />
+          <Label className={`${perUserRadioTileClass} relative`}>
+            <RadioGroupItem
+              value="fixed_date"
+              className="absolute opacity-0"
+            />
             <span className="min-w-0 flex-1 leading-snug">
               <span className="block text-sm font-medium">Expire on date</span>
               <span className="text-muted-foreground block text-xs font-normal">
@@ -191,8 +200,19 @@ export function AppCreditsConfigFields({
               </span>
             </span>
           </Label>
+          <Label className={`${perUserRadioTileClass} relative`}>
+            <RadioGroupItem value="earliest" className="absolute opacity-0" />
+            <span className="min-w-0 flex-1 leading-snug">
+              <span className="block text-sm font-medium">
+                Earliest of both
+              </span>
+              <span className="text-muted-foreground block text-xs font-normal">
+                Expire after X days or on a fixed date
+              </span>
+            </span>
+          </Label>
         </RadioGroup>
-        {expiryMode === "after_days" ? (
+        {expiryMode === "after_days" || expiryMode === "earliest" ? (
           <div className="grid gap-2 sm:max-w-xs">
             <Label htmlFor={`promotion-credit-expiry-days-${mode}`}>
               Days after redemption
@@ -208,7 +228,7 @@ export function AppCreditsConfigFields({
             />
           </div>
         ) : null}
-        {expiryMode === "fixed_date" ? (
+        {expiryMode === "fixed_date" || expiryMode === "earliest" ? (
           <div className="grid gap-2 sm:max-w-xs">
             <Label htmlFor={`promotion-credit-expiry-date-${mode}`}>
               Expiration date (local)

--- a/apps/tanstack-start/src/components/admin/promotion-form-helpers.ts
+++ b/apps/tanstack-start/src/components/admin/promotion-form-helpers.ts
@@ -16,7 +16,11 @@ export type SubscriptionDuration = "once" | "repeating" | "forever";
 export type DiscountType = "percent" | "amount";
 export type TargetTierMode = "all" | "plus" | "pro";
 export type AppCreditPlanEligibilityMode = "all" | "selected";
-export type AppCreditExpiryMode = "never" | "after_days" | "fixed_date";
+export type AppCreditExpiryMode =
+  | "never"
+  | "after_days"
+  | "fixed_date"
+  | "earliest";
 
 export type PromotionFormDialogPromotion = {
   promotionId: string;
@@ -223,7 +227,8 @@ export function validatePromotionForm(args: {
   const expiryDays = Number(args.appCreditExpiryDays);
   if (
     args.promotionType === "app_credits" &&
-    args.appCreditExpiryMode === "after_days" &&
+    (args.appCreditExpiryMode === "after_days" ||
+      args.appCreditExpiryMode === "earliest") &&
     (!Number.isInteger(expiryDays) || expiryDays <= 0)
   ) {
     return "Expiration days must be a positive integer.";
@@ -232,7 +237,8 @@ export function validatePromotionForm(args: {
   const expiryDateMs = parseDate(args.appCreditExpiryDate);
   if (
     args.promotionType === "app_credits" &&
-    args.appCreditExpiryMode === "fixed_date" &&
+    (args.appCreditExpiryMode === "fixed_date" ||
+      args.appCreditExpiryMode === "earliest") &&
     expiryDateMs === undefined
   ) {
     return "Expiration date is invalid.";
@@ -349,11 +355,14 @@ export function buildPromotionConfig(args: {
           args.appCreditPlanEligibilityMode === "all"
             ? "all"
             : args.appCreditSelectedPlanTiers,
-        ...(args.appCreditExpiryMode === "after_days"
+        ...(args.appCreditExpiryMode === "after_days" ||
+        args.appCreditExpiryMode === "earliest"
           ? { expiresAfterDays: expiryDays }
-          : args.appCreditExpiryMode === "fixed_date"
-            ? { expiresAt: expiryDateMs }
-            : {}),
+          : {}),
+        ...(args.appCreditExpiryMode === "fixed_date" ||
+        args.appCreditExpiryMode === "earliest"
+          ? { expiresAt: expiryDateMs }
+          : {}),
       },
     };
   }

--- a/apps/tanstack-start/src/components/admin/use-promotion-form.ts
+++ b/apps/tanstack-start/src/components/admin/use-promotion-form.ts
@@ -156,11 +156,14 @@ export function usePromotionForm(
     useReducerState<PlanTier[]>(initialAppCreditSelectedPlanTiers);
   const [appCreditExpiryMode, setAppCreditExpiryMode] =
     useReducerState<AppCreditExpiryMode>(
-      typeof config.expiresAfterDays === "number"
-        ? "after_days"
-        : typeof config.expiresAt === "number"
-          ? "fixed_date"
-          : "never",
+      typeof config.expiresAfterDays === "number" &&
+        typeof config.expiresAt === "number"
+        ? "earliest"
+        : typeof config.expiresAfterDays === "number"
+          ? "after_days"
+          : typeof config.expiresAt === "number"
+            ? "fixed_date"
+            : "never",
     );
   const [appCreditExpiryDays, setAppCreditExpiryDays] = useReducerState(
     typeof config.expiresAfterDays === "number"
@@ -235,11 +238,14 @@ export function usePromotionForm(
     setAppCreditPlanEligibilityMode(initialAppCreditPlanEligibilityMode);
     setAppCreditSelectedPlanTiers(initialAppCreditSelectedPlanTiers);
     setAppCreditExpiryMode(
-      typeof config.expiresAfterDays === "number"
-        ? "after_days"
-        : typeof config.expiresAt === "number"
-          ? "fixed_date"
-          : "never",
+      typeof config.expiresAfterDays === "number" &&
+        typeof config.expiresAt === "number"
+        ? "earliest"
+        : typeof config.expiresAfterDays === "number"
+          ? "after_days"
+          : typeof config.expiresAt === "number"
+            ? "fixed_date"
+            : "never",
     );
     setAppCreditExpiryDays(
       typeof config.expiresAfterDays === "number"

--- a/packages/backend/convex/functions/promotions.test.ts
+++ b/packages/backend/convex/functions/promotions.test.ts
@@ -2,7 +2,10 @@ import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../_generated/api";
-import { computePaidSubscriberPromotionFreeUntil } from "../promotions";
+import {
+  computePaidSubscriberPromotionFreeUntil,
+  resolveAppCreditExpiry,
+} from "../promotions";
 import schema from "../schema";
 import { modules } from "../test.setup";
 import {
@@ -20,6 +23,26 @@ const NOW = 1_700_000_000_000;
 function testDb() {
   return convexTest(schema, modules);
 }
+
+describe("resolveAppCreditExpiry", () => {
+  it("uses the earlier expiry when relative and fixed expiries are configured", () => {
+    expect(
+      resolveAppCreditExpiry({
+        expiresAfterDays: 30,
+        expiresAt: NOW + 10 * 86_400_000,
+        nowMs: NOW,
+      }),
+    ).toBe(NOW + 10 * 86_400_000);
+
+    expect(
+      resolveAppCreditExpiry({
+        expiresAfterDays: 7,
+        expiresAt: NOW + 10 * 86_400_000,
+        nowMs: NOW,
+      }),
+    ).toBe(NOW + 7 * 86_400_000);
+  });
+});
 
 async function insertAppCreditPromotion(
   t: ReturnType<typeof testDb>,

--- a/packages/backend/convex/promotions.ts
+++ b/packages/backend/convex/promotions.ts
@@ -103,9 +103,13 @@ export function resolveAppCreditExpiry(args: {
   expiresAfterDays?: number;
   nowMs?: number;
 }): number | undefined {
-  if (args.expiresAt !== undefined) return args.expiresAt;
-  if (args.expiresAfterDays === undefined) return undefined;
-  return (args.nowMs ?? Date.now()) + args.expiresAfterDays * 86_400_000;
+  const relativeExpiry =
+    args.expiresAfterDays === undefined
+      ? undefined
+      : (args.nowMs ?? Date.now()) + args.expiresAfterDays * 86_400_000;
+  if (args.expiresAt === undefined) return relativeExpiry;
+  if (relativeExpiry === undefined) return args.expiresAt;
+  return Math.min(args.expiresAt, relativeExpiry);
 }
 
 export function computePaidSubscriberPromotionFreeUntil(args: {

--- a/packages/shared/src/promotions.test.ts
+++ b/packages/shared/src/promotions.test.ts
@@ -140,6 +140,13 @@ describe("promotion helpers", () => {
       formatCreditExpiry({ amount: 100, expiresAt: 1735689600000 }),
     ).toMatch(/expires \d/);
     expect(
+      formatCreditExpiry({
+        amount: 100,
+        expiresAfterDays: 30,
+        expiresAt: 1735689600000,
+      }),
+    ).toMatch(/expires 30d after redeem or \d.*whichever comes first/);
+    expect(
       formatPromotionBenefit({
         kind: "app_credits",
         config: { amount: 1000, expiresAfterDays: 14 },

--- a/packages/shared/src/promotions.ts
+++ b/packages/shared/src/promotions.ts
@@ -171,6 +171,9 @@ export function discountedPriceCentsFromList(
 }
 
 export function formatCreditExpiry(config: AppCreditsPromotionConfig): string {
+  if (config.expiresAfterDays !== undefined && config.expiresAt !== undefined) {
+    return `expires ${config.expiresAfterDays}d after redeem or ${new Date(config.expiresAt).toLocaleDateString()}, whichever comes first`;
+  }
   if (config.expiresAfterDays !== undefined) {
     return `expires ${config.expiresAfterDays}d after redeem`;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "earliest expiry" mode for app credits—credits now expire based on whichever comes first between a set duration and a specific date.
  * Updated promotion configuration forms with horizontal radio group layouts.

* **Improvements**
  * Enhanced credit expiration messaging to display combined expiry conditions when both duration and date-based expiration are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->