### PR TITLE
Support SSE transport for MCP servers

### DIFF
--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -211,7 +211,7 @@ export function McpSettingsManager() {
           const authHeaders = server.authHeaders ?? [];
           return draft?.name !== server.name ||
             draft.url !== server.url ||
-            draft.transport !== (server.transport ?? "http") ||
+            draft.transport !== server.transport ||
             serializeAuthHeaders(draft.authHeaders) !==
               serializeAuthHeaders(authHeaders)
             ? [server.mcpServerId]
@@ -665,7 +665,7 @@ export function McpSettingsManager() {
                         </span>
                       ) : null}
                       <span className="text-muted-foreground bg-muted inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase">
-                        {server.transport ?? "http"}
+                        {server.transport}
                       </span>
                       {isConnected ? (
                         <span className="size-2 shrink-0 rounded-full bg-emerald-500" />

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -49,10 +49,12 @@ import { useQuery } from "@/lib/hooks/convex";
 import { useReducerState } from "@/lib/hooks/use-reducer-state";
 
 type McpToolPermission = "allow" | "ask" | "deny";
+type McpServerTransport = "http" | "sse";
 
 interface McpServerDraft {
   name: string;
   url: string;
+  transport: McpServerTransport;
   authHeaders: AuthHeaderDraft[];
 }
 
@@ -76,11 +78,13 @@ interface ServerToolState {
 function createDraft(server: {
   name: string;
   url: string;
+  transport?: McpServerTransport;
   authHeaders?: AuthHeaderDraft[];
 }): McpServerDraft {
   return {
     name: server.name,
     url: server.url,
+    transport: server.transport ?? "http",
     authHeaders: server.authHeaders ?? [],
   };
 }
@@ -139,6 +143,8 @@ export function McpSettingsManager() {
   >({});
   const [newServerName, setNewServerName] = useReducerState("");
   const [newServerUrl, setNewServerUrl] = useReducerState("");
+  const [newServerTransport, setNewServerTransport] =
+    useReducerState<McpServerTransport>("http");
   const [newAuthHeaders, setNewAuthHeaders] = useReducerState<
     AuthHeaderDraft[]
   >([]);
@@ -205,6 +211,7 @@ export function McpSettingsManager() {
           const authHeaders = server.authHeaders ?? [];
           return draft?.name !== server.name ||
             draft.url !== server.url ||
+            draft.transport !== (server.transport ?? "http") ||
             serializeAuthHeaders(draft.authHeaders) !==
               serializeAuthHeaders(authHeaders)
             ? [server.mcpServerId]
@@ -220,10 +227,12 @@ export function McpSettingsManager() {
       await createServer({
         name: newServerName,
         url: newServerUrl,
+        transport: newServerTransport,
         authHeaders: compactAuthHeaders(newAuthHeaders),
       });
       setNewServerName("");
       setNewServerUrl("");
+      setNewServerTransport("http");
       setNewAuthHeaders([]);
       setShowAddForm(false);
       toast.success("MCP server added");
@@ -247,6 +256,7 @@ export function McpSettingsManager() {
         patch: {
           name: draft.name,
           url: draft.url,
+          transport: draft.transport,
           authHeaders: compactAuthHeaders(draft.authHeaders),
         },
       });
@@ -535,6 +545,25 @@ export function McpSettingsManager() {
                     onChange={(e) => setNewServerUrl(e.target.value)}
                   />
                 </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="new-server-transport" className="text-xs">
+                    Transport
+                  </Label>
+                  <Select
+                    value={newServerTransport}
+                    onValueChange={(value) =>
+                      setNewServerTransport(value as McpServerTransport)
+                    }
+                  >
+                    <SelectTrigger id="new-server-transport">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="http">HTTP</SelectItem>
+                      <SelectItem value="sse">SSE</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
                 <AuthHeadersEditor
                   authHeaders={newAuthHeaders}
                   disabled={creating}
@@ -635,6 +664,9 @@ export function McpSettingsManager() {
                           OAuth
                         </span>
                       ) : null}
+                      <span className="text-muted-foreground bg-muted inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase">
+                        {server.transport ?? "http"}
+                      </span>
                       {isConnected ? (
                         <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
                       ) : toolState?.error ? (
@@ -801,6 +833,36 @@ export function McpSettingsManager() {
                             }))
                           }
                         />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <Label
+                          htmlFor={`edit-transport-${mcpServerId}`}
+                          className="text-xs"
+                        >
+                          Transport
+                        </Label>
+                        <Select
+                          value={draft.transport}
+                          disabled={isSaving || isDeleting}
+                          onValueChange={(value) =>
+                            setDrafts((current) => ({
+                              ...current,
+                              [mcpServerId]: {
+                                ...(current[mcpServerId] ??
+                                  createDraft(server)),
+                                transport: value as McpServerTransport,
+                              },
+                            }))
+                          }
+                        >
+                          <SelectTrigger id={`edit-transport-${mcpServerId}`}>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="http">HTTP</SelectItem>
+                            <SelectItem value="sse">SSE</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                       <AuthHeadersEditor
                         authHeaders={draft.authHeaders}

--- a/apps/tanstack-start/src/lib/ai/tools/index.ts
+++ b/apps/tanstack-start/src/lib/ai/tools/index.ts
@@ -29,12 +29,15 @@ import { resolveAiSdkImageModel } from "@/server/ai/model-runtime";
 
 export type { ChatToolAttachment };
 
+export type McpServerTransport = "http" | "sse";
+
 interface ToolRuntimeOptions {
   attachments?: ChatToolAttachment[];
   mcpServers?: {
     mcpServerId: string;
     name: string;
     url: string;
+    transport?: McpServerTransport;
     authHeaders?: {
       name: string;
       value: string;
@@ -294,6 +297,27 @@ export function createMcpFetch(url: string): typeof fetch {
   };
 }
 
+export function createMcpTransport({
+  url,
+  transport,
+  headers,
+  authProvider,
+}: {
+  url: string;
+  transport?: McpServerTransport;
+  headers?: Record<string, string>;
+  authProvider?: OAuthClientProvider;
+}) {
+  return {
+    type: transport ?? "http",
+    url,
+    headers,
+    authProvider,
+    redirect: "error" as const,
+    fetch: createMcpFetch(url),
+  };
+}
+
 export async function createToolRuntime(
   settings: MessageSettings,
   {
@@ -431,7 +455,6 @@ export async function createToolRuntime(
   if (enabledTools.includes("mcpServers")) {
     for (const server of mcpServers) {
       assertAllowedMcpServerUrl(server.url);
-      const mcpFetch = createMcpFetch(server.url);
 
       const authProvider = server.oauthTokens
         ? createChatOAuthProvider(server, async (tokens) => {
@@ -441,9 +464,9 @@ export async function createToolRuntime(
 
       const client = await createMCPClient({
         name: `redux-chat-${server.mcpServerId}`,
-        transport: {
-          type: "http",
+        transport: createMcpTransport({
           url: server.url,
+          transport: server.transport,
           headers: Object.fromEntries(
             (server.authHeaders ?? []).map((header) => [
               header.name,
@@ -451,9 +474,7 @@ export async function createToolRuntime(
             ]),
           ),
           authProvider,
-          redirect: "error",
-          fetch: mcpFetch,
-        },
+        }),
       });
       mcpClients.push(client);
 

--- a/apps/tanstack-start/src/routes/api/mcp/discover-tools.ts
+++ b/apps/tanstack-start/src/routes/api/mcp/discover-tools.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { api } from "@redux/backend/convex/_generated/api";
 
-import { assertAllowedMcpServerUrl, createMcpFetch } from "@/lib/ai/tools";
+import { assertAllowedMcpServerUrl, createMcpTransport } from "@/lib/ai/tools";
 import { fetchAuthQuery, getRequestUserIdFromHeaders } from "@/lib/auth/server";
 
 const requestSchema = z.object({
@@ -43,7 +43,6 @@ export const Route = createFileRoute("/api/mcp/discover-tools")({
         let client: Awaited<ReturnType<typeof createMCPClient>> | undefined;
         try {
           assertAllowedMcpServerUrl(server.url);
-          const mcpFetch = createMcpFetch(server.url);
 
           const headers: Record<string, string> = Object.fromEntries(
             server.authHeaders.map((h) => [h.name, h.value]),
@@ -55,13 +54,11 @@ export const Route = createFileRoute("/api/mcp/discover-tools")({
 
           client = await createMCPClient({
             name: `redux-chat-discover-${server.mcpServerId}`,
-            transport: {
-              type: "http",
+            transport: createMcpTransport({
               url: server.url,
+              transport: server.transport,
               headers,
-              redirect: "error",
-              fetch: mcpFetch,
-            },
+            }),
           });
 
           const serverTools = await client.tools();

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -42,6 +42,7 @@ describe("functions/mcpServers", () => {
         mcpServerId,
         name: "Local MCP",
         url: "https://example.com/mcp",
+        transport: "http",
         toolPermissions: {},
         hasOAuth: false,
         createdAt: NOW,
@@ -56,6 +57,7 @@ describe("functions/mcpServers", () => {
         mcpServerId,
         name: "Local MCP",
         url: "https://example.com/mcp",
+        transport: "http",
         authHeaders: [
           { name: "Authorization", value: "Bearer test-token" },
           { name: "X-Trace", value: "trace-id" },
@@ -64,6 +66,43 @@ describe("functions/mcpServers", () => {
         hasOAuth: false,
         createdAt: NOW,
         updatedAt: NOW,
+      },
+    ]);
+  });
+
+  it("stores and updates the MCP server transport", async () => {
+    const t = authedTest();
+
+    const { mcpServerId } = await t.mutation(api.functions.mcpServers.create, {
+      name: "SSE MCP",
+      url: "https://example.com/sse",
+      transport: "sse",
+    });
+
+    await expect(
+      t.query(api.functions.mcpServers.getByIds, {
+        serverIds: [mcpServerId],
+      }),
+    ).resolves.toMatchObject([
+      {
+        mcpServerId,
+        transport: "sse",
+      },
+    ]);
+
+    await t.mutation(api.functions.mcpServers.update, {
+      mcpServerId,
+      patch: {
+        transport: "http",
+      },
+    });
+
+    await expect(
+      t.query(api.functions.mcpServers.listConfigured),
+    ).resolves.toMatchObject([
+      {
+        mcpServerId,
+        transport: "http",
       },
     ]);
   });

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -13,6 +13,8 @@ const MAX_AUTH_HEADERS = 20;
 const MAX_HEADER_NAME_LENGTH = 128;
 const MAX_HEADER_VALUE_LENGTH = 4096;
 const headerNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const mcpServerTransport = v.union(v.literal("http"), v.literal("sse"));
+type McpServerTransport = "http" | "sse";
 const blockedMcpHostnames = new Set([
   "localhost",
   "metadata.google.internal",
@@ -39,6 +41,12 @@ function normalizeMcpServerName(name: string) {
   }
 
   return normalized;
+}
+
+function normalizeMcpServerTransport(
+  transport: McpServerTransport | undefined,
+) {
+  return transport ?? "http";
 }
 
 function isPrivateIpv4(hostname: string) {
@@ -306,6 +314,7 @@ async function listConfiguredServers(
     mcpServerId: server.mcpServerId,
     name: server.name,
     url: server.url,
+    transport: normalizeMcpServerTransport(server.transport),
     ...(options.includeAuthHeaders
       ? { authHeaders: server.authHeaders ?? [] }
       : {}),
@@ -381,6 +390,7 @@ export const getByIds = query({
           mcpServerId: server.mcpServerId,
           name: server.name,
           url: server.url,
+          transport: normalizeMcpServerTransport(server.transport),
           authHeaders: server.authHeaders ?? [],
           toolPermissions: server.toolPermissions ?? {},
           oauthTokens: server.oauthTokens,
@@ -398,6 +408,7 @@ export const create = mutation({
   args: {
     name: v.string(),
     url: v.string(),
+    transport: v.optional(mcpServerTransport),
     authHeaders: v.optional(
       v.array(
         v.object({
@@ -417,6 +428,7 @@ export const create = mutation({
       userId: ctx.userId,
       name: normalizeMcpServerName(args.name),
       url: normalizeMcpServerUrl(args.url),
+      transport: normalizeMcpServerTransport(args.transport),
       authHeaders: authHeaders.length > 0 ? authHeaders : undefined,
       createdAt: now,
       updatedAt: now,
@@ -434,6 +446,7 @@ export const update = mutation({
     patch: v.object({
       name: v.optional(v.string()),
       url: v.optional(v.string()),
+      transport: v.optional(mcpServerTransport),
       authHeaders: v.optional(
         v.array(
           v.object({
@@ -455,6 +468,10 @@ export const update = mutation({
       args.patch.url !== undefined
         ? normalizeMcpServerUrl(args.patch.url)
         : server.url;
+    const nextTransport =
+      args.patch.transport !== undefined
+        ? normalizeMcpServerTransport(args.patch.transport)
+        : normalizeMcpServerTransport(server.transport);
     const nextAuthHeaders =
       args.patch.authHeaders !== undefined
         ? normalizeMcpAuthHeaders(args.patch.authHeaders)
@@ -463,6 +480,7 @@ export const update = mutation({
     await ctx.db.patch(server._id, {
       name: nextName,
       url: nextUrl,
+      transport: nextTransport,
       authHeaders: nextAuthHeaders.length > 0 ? nextAuthHeaders : undefined,
       updatedAt: Date.now(),
     });
@@ -471,6 +489,7 @@ export const update = mutation({
       mcpServerId: server.mcpServerId,
       name: nextName,
       url: nextUrl,
+      transport: nextTransport,
       authHeaders: nextAuthHeaders,
     };
   },

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -157,6 +157,7 @@ export default defineSchema({
     userId: v.string(),
     name: v.string(),
     url: v.string(),
+    transport: v.optional(v.union(v.literal("http"), v.literal("sse"))),
     authHeaders: v.optional(
       v.array(
         v.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a persisted MCP server transport option with HTTP default and SSE support
- Use the selected transport for MCP tool discovery and chat tool runtime clients
- Add HTTP/SSE selection controls to MCP settings and cover transport persistence in tests

## Verification
- `pnpm -F @redux/backend test -- convex/functions/mcpServers.test.ts`
- `pnpm -F @redux/backend typecheck`
- `pnpm -F @redux/tanstack-start typecheck`
- `npx react-doctor@latest --verbose --diff` (88/100; no changed-file regressions)
- `NODE_OPTIONS=--experimental-strip-types pnpm -F @redux/backend lint`
- `NODE_OPTIONS=--experimental-strip-types pnpm -F @redux/tanstack-start lint` (passes with existing unrelated warning in `src/server/ai/telemetry.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f1c1714-ca2c-47a2-8ecf-c6064126a9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f1c1714-ca2c-47a2-8ecf-c6064126a9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP servers now support choosing a transport type: HTTP or SSE.
  * The transport is shown in the server list and can be set when adding or editing a server.

* **Bug Fixes**
  * Server transport is now saved consistently and reflected correctly after updates.
  * Existing servers without a saved transport now default to HTTP for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->