### PR TITLE
chore: Cloud Agent dev environment setup + dev-only auto-login routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,18 +65,29 @@ the notes below only cover non-obvious things needed to run it in a Cloud Agent.
   (`Attempted to access a server-side environment variable on the client`). They
   reproduce on a clean checkout and are unrelated to environment setup.
 
-### Dev-only admin login (`/api/dev-login`)
-For local development there is a dev-only auto-login route:
-`GET /api/dev-login` (on the app at `localhost` port `3712`). Visiting it provisions a fixed admin
-account (`dev-admin@local.test`) if missing — **it checks for an existing user
-first and skips creation if one exists** — signs in (setting the session
-cookie), ensures the account has the `admin` role, and redirects to `/`.
-- Implemented in `apps/tanstack-start/src/routes/api/dev-login.ts` (the route)
-  and `packages/backend/convex/functions/devAuth.ts` (`ensureDevAdmin`).
-- **Triple-gated:** the route 404s unless `NODE_ENV !== "production"`; the
-  Convex `ensureDevAdmin` mutation requires `INTERNAL_CONVEX_SECRET` (via
+### Dev-only auto-login (`/api/dev-login/*`)
+For local development there are dev-only auto-login routes (on the app at
+`localhost` port `3712`):
+- `GET /api/dev-login/user` — provisions/logs in a normal user
+  (`dev-user@local.test`).
+- `GET /api/dev-login/admin` — provisions/logs in an admin
+  (`dev-admin@local.test`, elevated to the `admin` role).
+- `GET /api/dev-login` — convenience alias that redirects to
+  `/api/dev-login/admin`.
+
+Each account route **checks for an existing user first and skips creation if one
+exists**, signs in (setting the session cookie), and redirects to `/`.
+- Implemented in `apps/tanstack-start/src/routes/api/dev-login/`
+  (`index.ts`/`user.ts`/`admin.ts`), the shared helper
+  `apps/tanstack-start/src/server/dev-login.ts`, and
+  `packages/backend/convex/functions/devAuth.ts` (`ensureDevAccount`).
+- **Triple-gated:** the routes 404 unless `NODE_ENV !== "production"`; the
+  Convex `ensureDevAccount` mutation requires `INTERNAL_CONVEX_SECRET` (via
   `backendMutation`) and refuses unless `SITE_URL` is a local origin. Do not
   loosen these gates.
+- New server route files require restarting the app dev server to register
+  their handlers (HMR regenerates the route tree but doesn't always re-register
+  server handlers).
 - After adding/editing Convex functions, redeploy + regen types: stop the local
   backend, run `pnpm -F @redux/backend exec convex dev --once` (codegen on),
   delete `convex/tsconfig.json`, then re-run `scripts/dev/cloud-local-backend.sh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,27 @@ the notes below only cover non-obvious things needed to run it in a Cloud Agent.
   (`Attempted to access a server-side environment variable on the client`). They
   reproduce on a clean checkout and are unrelated to environment setup.
 
+### Dev-only admin login (`/api/dev-login`)
+For local development there is a dev-only auto-login route:
+`GET /api/dev-login` (on the app at `localhost` port `3712`). Visiting it provisions a fixed admin
+account (`dev-admin@local.test`) if missing — **it checks for an existing user
+first and skips creation if one exists** — signs in (setting the session
+cookie), ensures the account has the `admin` role, and redirects to `/`.
+- Implemented in `apps/tanstack-start/src/routes/api/dev-login.ts` (the route)
+  and `packages/backend/convex/functions/devAuth.ts` (`ensureDevAdmin`).
+- **Triple-gated:** the route 404s unless `NODE_ENV !== "production"`; the
+  Convex `ensureDevAdmin` mutation requires `INTERNAL_CONVEX_SECRET` (via
+  `backendMutation`) and refuses unless `SITE_URL` is a local origin. Do not
+  loosen these gates.
+- After adding/editing Convex functions, redeploy + regen types: stop the local
+  backend, run `pnpm -F @redux/backend exec convex dev --once` (codegen on),
+  delete `convex/tsconfig.json`, then re-run `scripts/dev/cloud-local-backend.sh`.
+  Committing the regenerated `convex/_generated/api.d.ts` and
+  `apps/tanstack-start/src/routeTree.gen.ts` is expected.
+
 ### Verified working
 Sign up with email/password at `/auth/sign-up`, land in the authenticated chat,
 send a message, and the AI replies (e.g. "What is 7 times 6?" → "42"). This
 exercises the full stack: frontend → local Convex → Better Auth → DB → AI
-provider → Stripe billing.
+provider → Stripe billing. The `/api/dev-login` route logs in as an admin and
+`/admin` loads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ the notes below only cover non-obvious things needed to run it in a Cloud Agent.
   (there is no `engine-strict`), but **run the app/Convex with Node 24**.
 
 ### Services (all must run for end-to-end use)
+
 | Service | How to start | Notes |
 |---|---|---|
 | Local infra (Redis, etc.) | `docker compose up -d` | Docker isn't auto-started: run `sudo dockerd > /var/log/dockerd.log 2>&1 &` first if `docker` errors. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pnpm + Turborepo monorepo ("Redux Chat"): a TanStack Start web app
+(`apps/tanstack-start`, dev port **3712**) backed by a Convex backend
+(`packages/backend`). Standard commands live in `README.md` and `package.json`;
+the notes below only cover non-obvious things needed to run it in a Cloud Agent.
+
+### Toolchain / Node
+- The repo requires **Node 24** (`.nvmrc`), but the VM's default `node`
+  (`/exec-daemon/node`) is Node 22 and sits early in `PATH`. Interactive/login
+  shells are already fixed to use Node 24 + pnpm 10.33.2 via `~/.bashrc`
+  (`nvm use 24` + a `PATH` prepend), so `node`/`pnpm` work normally in tmux and
+  new terminals. The update script's `pnpm install` works on either Node version
+  (there is no `engine-strict`), but **run the app/Convex with Node 24**.
+
+### Services (all must run for end-to-end use)
+| Service | How to start | Notes |
+|---|---|---|
+| Local infra (Redis, etc.) | `docker compose up -d` | Docker isn't auto-started: run `sudo dockerd > /var/log/dockerd.log 2>&1 &` first if `docker` errors. |
+| Convex backend (local) | `bash scripts/dev/cloud-local-backend.sh` | Serves on `:3210` (API) / `:3211` (HTTP actions). See below. |
+| Web app | `pnpm -F @redux/tanstack-start dev` (or `pnpm dev`) | serves on `localhost` port `3712` |
+
+### Convex local backend (the non-obvious part)
+- There is **no cloud Convex**; an anonymous **local** deployment is used. Data
+  lives in `packages/backend/.convex/local/default/` (gitignored), so a fresh VM
+  starts empty and you must re-run the setup script.
+- `convex dev --once` spins up the local DB + deploys functions and then exits
+  (it does **not** keep serving). `scripts/dev/cloud-local-backend.sh` therefore
+  deploys with `--once`, then launches the persistent `convex-local-backend`
+  binary to keep `:3210` serving, and finally syncs secrets onto the deployment.
+  The script is idempotent.
+- **Secrets:** real credentials (OpenAI, OpenRouter, Stripe, Silo,
+  `INTERNAL_CONVEX_SECRET`, `AUTH_SECRET`, ...) are provided as injected Cloud
+  Agent env vars. The app reads them directly from its environment (injected env
+  overrides `.env`). The **Convex deployment** does NOT see them automatically —
+  the setup script copies them onto the deployment with `convex env set`. If chat
+  fails with `STRIPE_SECRET_KEY ... not set` or auth fails, re-run the script.
+- `INTERNAL_CONVEX_SECRET` **must match** between the app (injected) and the
+  Convex deployment, or sending a chat message fails with
+  `Invalid userMessageId signature`. The script keeps them aligned.
+- `AUTH_SECRET` is used by Better Auth to encrypt its JWKS in the DB. If you
+  change it after users exist you get `Failed to decrypt private key`; wipe
+  `packages/backend/.convex/local/default` and re-run the script to reset.
+- Only the local Convex URLs are added to `.env`
+  (`VITE_CONVEX_URL`/`VITE_CONVEX_SITE_URL`); everything else comes from injected
+  secrets. Recreate `.env` with `cp .env.example .env` then append those two vars
+  if needed.
+
+### Lint gotcha
+- `convex dev`/`convex codegen` (with codegen enabled) regenerates
+  `packages/backend/convex/_generated/**`, the `_generated/ai/*` + `.agents`
+  skills files, and an untracked `packages/backend/convex/tsconfig.json`. That
+  generated `convex/tsconfig.json` shadows the type-aware ESLint program and makes
+  `pnpm lint` report ~16 bogus `no-unnecessary-condition` errors. **Delete it**
+  (`rm -f packages/backend/convex/tsconfig.json`) before linting, or run convex
+  with `--codegen disable` (the setup script does both). Don't commit those
+  regenerated files.
+
+### Tests
+- `pnpm test` has **2 pre-existing failures** in `@redux/backend`
+  (`convex/http.test.ts` collection + `threadShares.test.ts` "forks a share")
+  caused by t3-env's server/client guard in the `edge-runtime` test env
+  (`Attempted to access a server-side environment variable on the client`). They
+  reproduce on a clean checkout and are unrelated to environment setup.
+
+### Verified working
+Sign up with email/password at `/auth/sign-up`, land in the authenticated chat,
+send a message, and the AI replies (e.g. "What is 7 times 6?" → "42"). This
+exercises the full stack: frontend → local Convex → Better Auth → DB → AI
+provider → Stripe billing.

--- a/apps/tanstack-start/src/routeTree.gen.ts
+++ b/apps/tanstack-start/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthSignOutRouteImport } from './routes/auth.sign-out'
 import { Route as AuthSignInRouteImport } from './routes/auth.sign-in'
 import { Route as AuthForgotPasswordRouteImport } from './routes/auth.forgot-password'
 import { Route as ApiUploadRouteImport } from './routes/api/upload'
+import { Route as ApiDevLoginRouteImport } from './routes/api/dev-login'
 import { Route as ApiDeploymentIdRouteImport } from './routes/api/deployment-id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AdminPromotionsRouteImport } from './routes/admin/promotions'
@@ -184,6 +185,11 @@ const ApiUploadRoute = ApiUploadRouteImport.update({
   path: '/api/upload',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiDevLoginRoute = ApiDevLoginRouteImport.update({
+  id: '/api/dev-login',
+  path: '/api/dev-login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiDeploymentIdRoute = ApiDeploymentIdRouteImport.update({
   id: '/api/deployment-id',
   path: '/api/deployment-id',
@@ -291,6 +297,7 @@ export interface FileRoutesByFullPath {
   '/admin/promotions': typeof AdminPromotionsRouteWithChildren
   '/admin/users': typeof AdminUsersRouteWithChildren
   '/api/deployment-id': typeof ApiDeploymentIdRoute
+  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -332,6 +339,7 @@ export interface FileRoutesByTo {
   '/components': typeof ComponentsRoute
   '/reasoning': typeof ReasoningRoute
   '/api/deployment-id': typeof ApiDeploymentIdRoute
+  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -380,6 +388,7 @@ export interface FileRoutesById {
   '/admin/promotions': typeof AdminPromotionsRouteWithChildren
   '/admin/users': typeof AdminUsersRouteWithChildren
   '/api/deployment-id': typeof ApiDeploymentIdRoute
+  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -429,6 +438,7 @@ export interface FileRouteTypes {
     | '/admin/promotions'
     | '/admin/users'
     | '/api/deployment-id'
+    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -470,6 +480,7 @@ export interface FileRouteTypes {
     | '/components'
     | '/reasoning'
     | '/api/deployment-id'
+    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -517,6 +528,7 @@ export interface FileRouteTypes {
     | '/admin/promotions'
     | '/admin/users'
     | '/api/deployment-id'
+    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -563,6 +575,7 @@ export interface RootRouteChildren {
   ReasoningRoute: typeof ReasoningRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   ApiDeploymentIdRoute: typeof ApiDeploymentIdRoute
+  ApiDevLoginRoute: typeof ApiDevLoginRoute
   ApiUploadRoute: typeof ApiUploadRoute
   IngestSplatRoute: typeof IngestSplatRoute
   RedeemCodeRoute: typeof RedeemCodeRoute
@@ -760,6 +773,13 @@ declare module '@tanstack/react-router' {
       path: '/api/upload'
       fullPath: '/api/upload'
       preLoaderRoute: typeof ApiUploadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/dev-login': {
+      id: '/api/dev-login'
+      path: '/api/dev-login'
+      fullPath: '/api/dev-login'
+      preLoaderRoute: typeof ApiDevLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/deployment-id': {
@@ -1010,6 +1030,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReasoningRoute: ReasoningRoute,
   SettingsRoute: SettingsRouteWithChildren,
   ApiDeploymentIdRoute: ApiDeploymentIdRoute,
+  ApiDevLoginRoute: ApiDevLoginRoute,
   ApiUploadRoute: ApiUploadRoute,
   IngestSplatRoute: IngestSplatRoute,
   RedeemCodeRoute: RedeemCodeRoute,

--- a/apps/tanstack-start/src/routeTree.gen.ts
+++ b/apps/tanstack-start/src/routeTree.gen.ts
@@ -35,10 +35,10 @@ import { Route as AuthSignOutRouteImport } from './routes/auth.sign-out'
 import { Route as AuthSignInRouteImport } from './routes/auth.sign-in'
 import { Route as AuthForgotPasswordRouteImport } from './routes/auth.forgot-password'
 import { Route as ApiUploadRouteImport } from './routes/api/upload'
-import { Route as ApiDevLoginRouteImport } from './routes/api/dev-login'
 import { Route as ApiDeploymentIdRouteImport } from './routes/api/deployment-id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AdminPromotionsRouteImport } from './routes/admin/promotions'
+import { Route as ApiDevLoginIndexRouteImport } from './routes/api/dev-login/index'
 import { Route as ApiChatIndexRouteImport } from './routes/api/chat/index'
 import { Route as AdminUsersIndexRouteImport } from './routes/admin/users/index'
 import { Route as AdminPromotionsIndexRouteImport } from './routes/admin/promotions/index'
@@ -46,6 +46,8 @@ import { Route as AppProjectsIndexRouteImport } from './routes/_app/projects.ind
 import { Route as ApiWebhookStripeRouteImport } from './routes/api/webhook/stripe'
 import { Route as ApiSsoFeaturebaseRouteImport } from './routes/api/sso/featurebase'
 import { Route as ApiMcpDiscoverToolsRouteImport } from './routes/api/mcp/discover-tools'
+import { Route as ApiDevLoginUserRouteImport } from './routes/api/dev-login/user'
+import { Route as ApiDevLoginAdminRouteImport } from './routes/api/dev-login/admin'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AdminUsersUserIdRouteImport } from './routes/admin/users.$userId'
 import { Route as AdminPromotionsPromotionIdRouteImport } from './routes/admin/promotions.$promotionId'
@@ -185,11 +187,6 @@ const ApiUploadRoute = ApiUploadRouteImport.update({
   path: '/api/upload',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiDevLoginRoute = ApiDevLoginRouteImport.update({
-  id: '/api/dev-login',
-  path: '/api/dev-login',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiDeploymentIdRoute = ApiDeploymentIdRouteImport.update({
   id: '/api/deployment-id',
   path: '/api/deployment-id',
@@ -204,6 +201,11 @@ const AdminPromotionsRoute = AdminPromotionsRouteImport.update({
   id: '/promotions',
   path: '/promotions',
   getParentRoute: () => AdminRoute,
+} as any)
+const ApiDevLoginIndexRoute = ApiDevLoginIndexRouteImport.update({
+  id: '/api/dev-login/',
+  path: '/api/dev-login/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ApiChatIndexRoute = ApiChatIndexRouteImport.update({
   id: '/api/chat/',
@@ -238,6 +240,16 @@ const ApiSsoFeaturebaseRoute = ApiSsoFeaturebaseRouteImport.update({
 const ApiMcpDiscoverToolsRoute = ApiMcpDiscoverToolsRouteImport.update({
   id: '/api/mcp/discover-tools',
   path: '/api/mcp/discover-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDevLoginUserRoute = ApiDevLoginUserRouteImport.update({
+  id: '/api/dev-login/user',
+  path: '/api/dev-login/user',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDevLoginAdminRoute = ApiDevLoginAdminRouteImport.update({
+  id: '/api/dev-login/admin',
+  path: '/api/dev-login/admin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
@@ -297,7 +309,6 @@ export interface FileRoutesByFullPath {
   '/admin/promotions': typeof AdminPromotionsRouteWithChildren
   '/admin/users': typeof AdminUsersRouteWithChildren
   '/api/deployment-id': typeof ApiDeploymentIdRoute
-  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -323,6 +334,8 @@ export interface FileRoutesByFullPath {
   '/admin/promotions/$promotionId': typeof AdminPromotionsPromotionIdRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/dev-login/admin': typeof ApiDevLoginAdminRoute
+  '/api/dev-login/user': typeof ApiDevLoginUserRoute
   '/api/mcp/discover-tools': typeof ApiMcpDiscoverToolsRoute
   '/api/sso/featurebase': typeof ApiSsoFeaturebaseRoute
   '/api/webhook/stripe': typeof ApiWebhookStripeRoute
@@ -330,6 +343,7 @@ export interface FileRoutesByFullPath {
   '/admin/promotions/': typeof AdminPromotionsIndexRoute
   '/admin/users/': typeof AdminUsersIndexRoute
   '/api/chat/': typeof ApiChatIndexRoute
+  '/api/dev-login/': typeof ApiDevLoginIndexRoute
   '/api/mcp/oauth/authorize': typeof ApiMcpOauthAuthorizeRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/chat/$id/stream/': typeof ApiChatIdStreamIndexRoute
@@ -339,7 +353,6 @@ export interface FileRoutesByTo {
   '/components': typeof ComponentsRoute
   '/reasoning': typeof ReasoningRoute
   '/api/deployment-id': typeof ApiDeploymentIdRoute
-  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -366,6 +379,8 @@ export interface FileRoutesByTo {
   '/admin/promotions/$promotionId': typeof AdminPromotionsPromotionIdRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/dev-login/admin': typeof ApiDevLoginAdminRoute
+  '/api/dev-login/user': typeof ApiDevLoginUserRoute
   '/api/mcp/discover-tools': typeof ApiMcpDiscoverToolsRoute
   '/api/sso/featurebase': typeof ApiSsoFeaturebaseRoute
   '/api/webhook/stripe': typeof ApiWebhookStripeRoute
@@ -373,6 +388,7 @@ export interface FileRoutesByTo {
   '/admin/promotions': typeof AdminPromotionsIndexRoute
   '/admin/users': typeof AdminUsersIndexRoute
   '/api/chat': typeof ApiChatIndexRoute
+  '/api/dev-login': typeof ApiDevLoginIndexRoute
   '/api/mcp/oauth/authorize': typeof ApiMcpOauthAuthorizeRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/chat/$id/stream': typeof ApiChatIdStreamIndexRoute
@@ -388,7 +404,6 @@ export interface FileRoutesById {
   '/admin/promotions': typeof AdminPromotionsRouteWithChildren
   '/admin/users': typeof AdminUsersRouteWithChildren
   '/api/deployment-id': typeof ApiDeploymentIdRoute
-  '/api/dev-login': typeof ApiDevLoginRoute
   '/api/upload': typeof ApiUploadRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/sign-in': typeof AuthSignInRoute
@@ -415,6 +430,8 @@ export interface FileRoutesById {
   '/admin/promotions/$promotionId': typeof AdminPromotionsPromotionIdRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/dev-login/admin': typeof ApiDevLoginAdminRoute
+  '/api/dev-login/user': typeof ApiDevLoginUserRoute
   '/api/mcp/discover-tools': typeof ApiMcpDiscoverToolsRoute
   '/api/sso/featurebase': typeof ApiSsoFeaturebaseRoute
   '/api/webhook/stripe': typeof ApiWebhookStripeRoute
@@ -422,6 +439,7 @@ export interface FileRoutesById {
   '/admin/promotions/': typeof AdminPromotionsIndexRoute
   '/admin/users/': typeof AdminUsersIndexRoute
   '/api/chat/': typeof ApiChatIndexRoute
+  '/api/dev-login/': typeof ApiDevLoginIndexRoute
   '/api/mcp/oauth/authorize': typeof ApiMcpOauthAuthorizeRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/chat/$id/stream/': typeof ApiChatIdStreamIndexRoute
@@ -438,7 +456,6 @@ export interface FileRouteTypes {
     | '/admin/promotions'
     | '/admin/users'
     | '/api/deployment-id'
-    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -464,6 +481,8 @@ export interface FileRouteTypes {
     | '/admin/promotions/$promotionId'
     | '/admin/users/$userId'
     | '/api/auth/$'
+    | '/api/dev-login/admin'
+    | '/api/dev-login/user'
     | '/api/mcp/discover-tools'
     | '/api/sso/featurebase'
     | '/api/webhook/stripe'
@@ -471,6 +490,7 @@ export interface FileRouteTypes {
     | '/admin/promotions/'
     | '/admin/users/'
     | '/api/chat/'
+    | '/api/dev-login/'
     | '/api/mcp/oauth/authorize'
     | '/api/mcp/oauth/callback'
     | '/api/chat/$id/stream/'
@@ -480,7 +500,6 @@ export interface FileRouteTypes {
     | '/components'
     | '/reasoning'
     | '/api/deployment-id'
-    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -507,6 +526,8 @@ export interface FileRouteTypes {
     | '/admin/promotions/$promotionId'
     | '/admin/users/$userId'
     | '/api/auth/$'
+    | '/api/dev-login/admin'
+    | '/api/dev-login/user'
     | '/api/mcp/discover-tools'
     | '/api/sso/featurebase'
     | '/api/webhook/stripe'
@@ -514,6 +535,7 @@ export interface FileRouteTypes {
     | '/admin/promotions'
     | '/admin/users'
     | '/api/chat'
+    | '/api/dev-login'
     | '/api/mcp/oauth/authorize'
     | '/api/mcp/oauth/callback'
     | '/api/chat/$id/stream'
@@ -528,7 +550,6 @@ export interface FileRouteTypes {
     | '/admin/promotions'
     | '/admin/users'
     | '/api/deployment-id'
-    | '/api/dev-login'
     | '/api/upload'
     | '/auth/forgot-password'
     | '/auth/sign-in'
@@ -555,6 +576,8 @@ export interface FileRouteTypes {
     | '/admin/promotions/$promotionId'
     | '/admin/users/$userId'
     | '/api/auth/$'
+    | '/api/dev-login/admin'
+    | '/api/dev-login/user'
     | '/api/mcp/discover-tools'
     | '/api/sso/featurebase'
     | '/api/webhook/stripe'
@@ -562,6 +585,7 @@ export interface FileRouteTypes {
     | '/admin/promotions/'
     | '/admin/users/'
     | '/api/chat/'
+    | '/api/dev-login/'
     | '/api/mcp/oauth/authorize'
     | '/api/mcp/oauth/callback'
     | '/api/chat/$id/stream/'
@@ -575,17 +599,19 @@ export interface RootRouteChildren {
   ReasoningRoute: typeof ReasoningRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   ApiDeploymentIdRoute: typeof ApiDeploymentIdRoute
-  ApiDevLoginRoute: typeof ApiDevLoginRoute
   ApiUploadRoute: typeof ApiUploadRoute
   IngestSplatRoute: typeof IngestSplatRoute
   RedeemCodeRoute: typeof RedeemCodeRoute
   LogosIndexRoute: typeof LogosIndexRoute
   TestIndexRoute: typeof TestIndexRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiDevLoginAdminRoute: typeof ApiDevLoginAdminRoute
+  ApiDevLoginUserRoute: typeof ApiDevLoginUserRoute
   ApiMcpDiscoverToolsRoute: typeof ApiMcpDiscoverToolsRoute
   ApiSsoFeaturebaseRoute: typeof ApiSsoFeaturebaseRoute
   ApiWebhookStripeRoute: typeof ApiWebhookStripeRoute
   ApiChatIndexRoute: typeof ApiChatIndexRoute
+  ApiDevLoginIndexRoute: typeof ApiDevLoginIndexRoute
   ApiMcpOauthAuthorizeRoute: typeof ApiMcpOauthAuthorizeRoute
   ApiMcpOauthCallbackRoute: typeof ApiMcpOauthCallbackRoute
   ApiChatIdStreamIndexRoute: typeof ApiChatIdStreamIndexRoute
@@ -775,13 +801,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiUploadRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/dev-login': {
-      id: '/api/dev-login'
-      path: '/api/dev-login'
-      fullPath: '/api/dev-login'
-      preLoaderRoute: typeof ApiDevLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/deployment-id': {
       id: '/api/deployment-id'
       path: '/api/deployment-id'
@@ -802,6 +821,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/promotions'
       preLoaderRoute: typeof AdminPromotionsRouteImport
       parentRoute: typeof AdminRoute
+    }
+    '/api/dev-login/': {
+      id: '/api/dev-login/'
+      path: '/api/dev-login'
+      fullPath: '/api/dev-login/'
+      preLoaderRoute: typeof ApiDevLoginIndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/chat/': {
       id: '/api/chat/'
@@ -850,6 +876,20 @@ declare module '@tanstack/react-router' {
       path: '/api/mcp/discover-tools'
       fullPath: '/api/mcp/discover-tools'
       preLoaderRoute: typeof ApiMcpDiscoverToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/dev-login/user': {
+      id: '/api/dev-login/user'
+      path: '/api/dev-login/user'
+      fullPath: '/api/dev-login/user'
+      preLoaderRoute: typeof ApiDevLoginUserRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/dev-login/admin': {
+      id: '/api/dev-login/admin'
+      path: '/api/dev-login/admin'
+      fullPath: '/api/dev-login/admin'
+      preLoaderRoute: typeof ApiDevLoginAdminRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/$': {
@@ -1030,17 +1070,19 @@ const rootRouteChildren: RootRouteChildren = {
   ReasoningRoute: ReasoningRoute,
   SettingsRoute: SettingsRouteWithChildren,
   ApiDeploymentIdRoute: ApiDeploymentIdRoute,
-  ApiDevLoginRoute: ApiDevLoginRoute,
   ApiUploadRoute: ApiUploadRoute,
   IngestSplatRoute: IngestSplatRoute,
   RedeemCodeRoute: RedeemCodeRoute,
   LogosIndexRoute: LogosIndexRoute,
   TestIndexRoute: TestIndexRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiDevLoginAdminRoute: ApiDevLoginAdminRoute,
+  ApiDevLoginUserRoute: ApiDevLoginUserRoute,
   ApiMcpDiscoverToolsRoute: ApiMcpDiscoverToolsRoute,
   ApiSsoFeaturebaseRoute: ApiSsoFeaturebaseRoute,
   ApiWebhookStripeRoute: ApiWebhookStripeRoute,
   ApiChatIndexRoute: ApiChatIndexRoute,
+  ApiDevLoginIndexRoute: ApiDevLoginIndexRoute,
   ApiMcpOauthAuthorizeRoute: ApiMcpOauthAuthorizeRoute,
   ApiMcpOauthCallbackRoute: ApiMcpOauthCallbackRoute,
   ApiChatIdStreamIndexRoute: ApiChatIdStreamIndexRoute,

--- a/apps/tanstack-start/src/routes/api/dev-login.ts
+++ b/apps/tanstack-start/src/routes/api/dev-login.ts
@@ -1,0 +1,100 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ConvexHttpClient } from "convex/browser";
+
+import { api } from "@redux/backend/convex/_generated/api";
+
+import { env } from "@/env";
+import { handler } from "@/lib/auth/server";
+
+// Fixed dev-only admin account. This route is disabled in production builds.
+const DEV_ADMIN_NAME = "Dev Admin";
+const DEV_ADMIN_EMAIL = "dev-admin@local.test";
+const DEV_ADMIN_PASSWORD = "dev-admin-12345!";
+
+function notFound() {
+  return new Response("Not Found", { status: 404 });
+}
+
+async function postAuth(origin: string, path: string, body: unknown) {
+  return handler(
+    new Request(`${origin}${path}`, {
+      method: "POST",
+      // Better Auth enforces a trusted Origin header (CSRF protection), so mirror
+      // the app origin on these server-constructed requests.
+      headers: {
+        "content-type": "application/json",
+        origin,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+/** Build a redirect that carries over the Set-Cookie headers from an auth response. */
+function redirectWithCookies(authResponse: Response, location: string) {
+  const response = new Response(null, {
+    status: 303,
+    headers: { Location: location },
+  });
+  for (const cookie of authResponse.headers.getSetCookie()) {
+    response.headers.append("set-cookie", cookie);
+  }
+  return response;
+}
+
+async function devLogin(request: Request): Promise<Response> {
+  // Hard gate: never expose this in production.
+  if (env.NODE_ENV === "production") {
+    return notFound();
+  }
+
+  const origin = new URL(request.url).origin;
+  const convex = new ConvexHttpClient(env.VITE_CONVEX_URL);
+
+  // Duplicate check (+ admin elevation if the account already exists). Gated on
+  // the backend by INTERNAL_CONVEX_SECRET and a local-deployment check.
+  const { existed } = await convex.mutation(api.functions.devAuth.ensureDevAdmin, {
+    secret: env.INTERNAL_CONVEX_SECRET,
+    email: DEV_ADMIN_EMAIL,
+  });
+
+  let authResponse: Response;
+  if (existed) {
+    // Account already exists — skip creation and just sign in.
+    authResponse = await postAuth(origin, "/api/auth/sign-in/email", {
+      email: DEV_ADMIN_EMAIL,
+      password: DEV_ADMIN_PASSWORD,
+    });
+  } else {
+    // Provision the account (Better Auth auto-signs in), then elevate to admin.
+    authResponse = await postAuth(origin, "/api/auth/sign-up/email", {
+      name: DEV_ADMIN_NAME,
+      email: DEV_ADMIN_EMAIL,
+      password: DEV_ADMIN_PASSWORD,
+    });
+    if (authResponse.ok) {
+      await convex.mutation(api.functions.devAuth.ensureDevAdmin, {
+        secret: env.INTERNAL_CONVEX_SECRET,
+        email: DEV_ADMIN_EMAIL,
+      });
+    }
+  }
+
+  if (!authResponse.ok) {
+    const detail = await authResponse.text();
+    return new Response(`Dev login failed (${authResponse.status}): ${detail}`, {
+      status: 500,
+    });
+  }
+
+  return redirectWithCookies(authResponse, "/");
+}
+
+export const Route = createFileRoute("/api/dev-login")({
+  server: {
+    handlers: {
+      GET: ({ request }) => devLogin(request),
+      POST: ({ request }) => devLogin(request),
+    },
+  },
+});

--- a/apps/tanstack-start/src/routes/api/dev-login/admin.ts
+++ b/apps/tanstack-start/src/routes/api/dev-login/admin.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DEV_ACCOUNTS, devLoginResponse } from "@/server/dev-login";
+
+export const Route = createFileRoute("/api/dev-login/admin")({
+  server: {
+    handlers: {
+      GET: ({ request }) => devLoginResponse(request, DEV_ACCOUNTS.admin),
+      POST: ({ request }) => devLoginResponse(request, DEV_ACCOUNTS.admin),
+    },
+  },
+});

--- a/apps/tanstack-start/src/routes/api/dev-login/index.ts
+++ b/apps/tanstack-start/src/routes/api/dev-login/index.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { isDevLoginEnabled, notFound } from "@/server/dev-login";
+
+// `/api/dev-login` is a convenience alias that redirects to the admin login.
+function redirectToAdmin() {
+  if (!isDevLoginEnabled()) {
+    return notFound();
+  }
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/api/dev-login/admin" },
+  });
+}
+
+export const Route = createFileRoute("/api/dev-login/")({
+  server: {
+    handlers: {
+      GET: () => redirectToAdmin(),
+      POST: () => redirectToAdmin(),
+    },
+  },
+});

--- a/apps/tanstack-start/src/routes/api/dev-login/user.ts
+++ b/apps/tanstack-start/src/routes/api/dev-login/user.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DEV_ACCOUNTS, devLoginResponse } from "@/server/dev-login";
+
+export const Route = createFileRoute("/api/dev-login/user")({
+  server: {
+    handlers: {
+      GET: ({ request }) => devLoginResponse(request, DEV_ACCOUNTS.user),
+      POST: ({ request }) => devLoginResponse(request, DEV_ACCOUNTS.user),
+    },
+  },
+});

--- a/apps/tanstack-start/src/server/dev-login.ts
+++ b/apps/tanstack-start/src/server/dev-login.ts
@@ -123,9 +123,12 @@ export async function devLoginResponse(
 
   if (!authResponse.ok) {
     const detail = await authResponse.text();
-    return new Response(`Dev login failed (${authResponse.status}): ${detail}`, {
-      status: 500,
-    });
+    return new Response(
+      `Dev login failed (${authResponse.status}): ${detail}`,
+      {
+        status: 500,
+      },
+    );
   }
 
   return redirectWithCookies(authResponse, "/");

--- a/apps/tanstack-start/src/server/dev-login.ts
+++ b/apps/tanstack-start/src/server/dev-login.ts
@@ -80,22 +80,25 @@ export async function devLoginResponse(
 
   // Duplicate check (+ admin elevation when requested). Gated on the backend by
   // INTERNAL_CONVEX_SECRET and a local-deployment check.
-  const { existed } = await convex.mutation(
-    api.functions.devAuth.ensureDevAccount,
-    {
+  const ensureAccount = () =>
+    convex.mutation(api.functions.devAuth.ensureDevAccount, {
       secret: env.INTERNAL_CONVEX_SECRET,
       email: account.email,
       admin: account.admin,
-    },
-  );
+    });
+
+  const signIn = () =>
+    postAuth(origin, "/api/auth/sign-in/email", {
+      email: account.email,
+      password: account.password,
+    });
+
+  const { existed } = await ensureAccount();
 
   let authResponse: Response;
   if (existed) {
     // Account already exists — skip creation and just sign in.
-    authResponse = await postAuth(origin, "/api/auth/sign-in/email", {
-      email: account.email,
-      password: account.password,
-    });
+    authResponse = await signIn();
   } else {
     // Provision the account (Better Auth auto-signs in).
     authResponse = await postAuth(origin, "/api/auth/sign-up/email", {
@@ -103,13 +106,18 @@ export async function devLoginResponse(
       email: account.email,
       password: account.password,
     });
-    // Elevate to admin only for admin accounts, once the user exists.
-    if (authResponse.ok && account.admin) {
-      await convex.mutation(api.functions.devAuth.ensureDevAccount, {
-        secret: env.INTERNAL_CONVEX_SECRET,
-        email: account.email,
-        admin: true,
-      });
+
+    if (authResponse.ok) {
+      // Elevate to admin only for admin accounts, once the user exists.
+      if (account.admin) {
+        await ensureAccount();
+      }
+    } else {
+      // Sign-up can fail if the account was created concurrently (duplicate
+      // email race). Treat it as retryable: re-ensure (elevating admins) and
+      // fall back to signing in instead of returning a hard 500.
+      await ensureAccount();
+      authResponse = await signIn();
     }
   }
 

--- a/apps/tanstack-start/src/server/dev-login.ts
+++ b/apps/tanstack-start/src/server/dev-login.ts
@@ -1,4 +1,3 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { ConvexHttpClient } from "convex/browser";
 
 import { api } from "@redux/backend/convex/_generated/api";
@@ -6,12 +5,34 @@ import { api } from "@redux/backend/convex/_generated/api";
 import { env } from "@/env";
 import { handler } from "@/lib/auth/server";
 
-// Fixed dev-only admin account. This route is disabled in production builds.
-const DEV_ADMIN_NAME = "Dev Admin";
-const DEV_ADMIN_EMAIL = "dev-admin@local.test";
-const DEV_ADMIN_PASSWORD = "dev-admin-12345!";
+// Fixed dev-only accounts. These routes are disabled in production builds.
+export interface DevAccount {
+  name: string;
+  email: string;
+  password: string;
+  admin: boolean;
+}
 
-function notFound() {
+export const DEV_ACCOUNTS = {
+  admin: {
+    name: "Dev Admin",
+    email: "dev-admin@local.test",
+    password: "dev-admin-12345!",
+    admin: true,
+  },
+  user: {
+    name: "Dev User",
+    email: "dev-user@local.test",
+    password: "dev-user-12345!",
+    admin: false,
+  },
+} satisfies Record<string, DevAccount>;
+
+export function isDevLoginEnabled() {
+  return env.NODE_ENV !== "production";
+}
+
+export function notFound() {
   return new Response("Not Found", { status: 404 });
 }
 
@@ -42,40 +63,52 @@ function redirectWithCookies(authResponse: Response, location: string) {
   return response;
 }
 
-async function devLogin(request: Request): Promise<Response> {
-  // Hard gate: never expose this in production.
-  if (env.NODE_ENV === "production") {
+/**
+ * Provision (if missing) and sign in the given dev account, then redirect to `/`.
+ * Existing accounts are detected first so creation is skipped. Disabled in prod.
+ */
+export async function devLoginResponse(
+  request: Request,
+  account: DevAccount,
+): Promise<Response> {
+  if (!isDevLoginEnabled()) {
     return notFound();
   }
 
   const origin = new URL(request.url).origin;
   const convex = new ConvexHttpClient(env.VITE_CONVEX_URL);
 
-  // Duplicate check (+ admin elevation if the account already exists). Gated on
-  // the backend by INTERNAL_CONVEX_SECRET and a local-deployment check.
-  const { existed } = await convex.mutation(api.functions.devAuth.ensureDevAdmin, {
-    secret: env.INTERNAL_CONVEX_SECRET,
-    email: DEV_ADMIN_EMAIL,
-  });
+  // Duplicate check (+ admin elevation when requested). Gated on the backend by
+  // INTERNAL_CONVEX_SECRET and a local-deployment check.
+  const { existed } = await convex.mutation(
+    api.functions.devAuth.ensureDevAccount,
+    {
+      secret: env.INTERNAL_CONVEX_SECRET,
+      email: account.email,
+      admin: account.admin,
+    },
+  );
 
   let authResponse: Response;
   if (existed) {
     // Account already exists — skip creation and just sign in.
     authResponse = await postAuth(origin, "/api/auth/sign-in/email", {
-      email: DEV_ADMIN_EMAIL,
-      password: DEV_ADMIN_PASSWORD,
+      email: account.email,
+      password: account.password,
     });
   } else {
-    // Provision the account (Better Auth auto-signs in), then elevate to admin.
+    // Provision the account (Better Auth auto-signs in).
     authResponse = await postAuth(origin, "/api/auth/sign-up/email", {
-      name: DEV_ADMIN_NAME,
-      email: DEV_ADMIN_EMAIL,
-      password: DEV_ADMIN_PASSWORD,
+      name: account.name,
+      email: account.email,
+      password: account.password,
     });
-    if (authResponse.ok) {
-      await convex.mutation(api.functions.devAuth.ensureDevAdmin, {
+    // Elevate to admin only for admin accounts, once the user exists.
+    if (authResponse.ok && account.admin) {
+      await convex.mutation(api.functions.devAuth.ensureDevAccount, {
         secret: env.INTERNAL_CONVEX_SECRET,
-        email: DEV_ADMIN_EMAIL,
+        email: account.email,
+        admin: true,
       });
     }
   }
@@ -89,12 +122,3 @@ async function devLogin(request: Request): Promise<Response> {
 
   return redirectWithCookies(authResponse, "/");
 }
-
-export const Route = createFileRoute("/api/dev-login")({
-  server: {
-    handlers: {
-      GET: ({ request }) => devLogin(request),
-      POST: ({ request }) => devLogin(request),
-    },
-  },
-});

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as functions_billing from "../functions/billing.js";
 import type * as functions_chatScrollPreferences from "../functions/chatScrollPreferences.js";
 import type * as functions_credits from "../functions/credits.js";
 import type * as functions_defaultMessageSettings from "../functions/defaultMessageSettings.js";
+import type * as functions_devAuth from "../functions/devAuth.js";
 import type * as functions_embeddings from "../functions/embeddings.js";
 import type * as functions_generatedImages from "../functions/generatedImages.js";
 import type * as functions_index from "../functions/index.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   "functions/chatScrollPreferences": typeof functions_chatScrollPreferences;
   "functions/credits": typeof functions_credits;
   "functions/defaultMessageSettings": typeof functions_defaultMessageSettings;
+  "functions/devAuth": typeof functions_devAuth;
   "functions/embeddings": typeof functions_embeddings;
   "functions/generatedImages": typeof functions_generatedImages;
   "functions/index": typeof functions_index;

--- a/packages/backend/convex/functions/devAuth.ts
+++ b/packages/backend/convex/functions/devAuth.ts
@@ -18,9 +18,20 @@ function rolesFromAuthRoleField(role: string | null | undefined): string[] {
 /** Only allow the dev-login helper against a local (non-production) deployment. */
 function assertLocalDeployment() {
   const siteUrl = backendEnv().SITE_URL;
+  let hostname: string;
+  let protocol: string;
+  try {
+    ({ hostname, protocol } = new URL(siteUrl));
+  } catch {
+    throw new ConvexError("ensureDevAccount requires a valid local SITE_URL");
+  }
+  // Parse the URL (rather than prefix-matching) so hosts like
+  // "http://localhost.attacker.test" cannot bypass the local-only gate.
   const isLocal =
-    siteUrl.startsWith("http://localhost") ||
-    siteUrl.startsWith("http://127.0.0.1");
+    protocol === "http:" &&
+    (hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1");
   if (!isLocal) {
     throw new ConvexError(
       "ensureDevAccount is only available on local development deployments",

--- a/packages/backend/convex/functions/devAuth.ts
+++ b/packages/backend/convex/functions/devAuth.ts
@@ -1,0 +1,74 @@
+import { ConvexError, v } from "convex/values";
+
+import { initAuth } from "../auth";
+import { backendEnv } from "../env";
+import { backendMutation } from "./index";
+
+/** Better Auth stores roles as a comma-separated string; default to ["user"]. */
+function rolesFromAuthRoleField(role: string | null | undefined): string[] {
+  if (role == null || role === "") {
+    return ["user"];
+  }
+  return role
+    .split(",")
+    .map((r) => r.trim())
+    .filter((r) => r.length > 0);
+}
+
+/** Only allow the dev-login helper against a local (non-production) deployment. */
+function assertLocalDeployment() {
+  const siteUrl = backendEnv().SITE_URL;
+  const isLocal =
+    siteUrl.startsWith("http://localhost") ||
+    siteUrl.startsWith("http://127.0.0.1");
+  if (!isLocal) {
+    throw new ConvexError(
+      "ensureDevAdmin is only available on local development deployments",
+    );
+  }
+}
+
+/**
+ * Dev-only helper used by the `/api/dev-login` route. Looks up a Better Auth
+ * user by email (duplicate check) and, if it exists, ensures it has the "admin"
+ * role. Account *creation* is intentionally handled by the app route via the
+ * normal Better Auth sign-up endpoint so the browser session cookie is set.
+ *
+ * Protected by `backendMutation` (requires INTERNAL_CONVEX_SECRET) and gated to
+ * local deployments only.
+ */
+export const ensureDevAdmin = backendMutation({
+  args: { email: v.string() },
+  handler: async (ctx, { email }) => {
+    assertLocalDeployment();
+
+    const auth = initAuth(ctx);
+    const { adapter } = await auth.$context;
+
+    const existing = await adapter.findOne<{
+      id: string;
+      email: string;
+      role?: string | null;
+    }>({
+      model: "user",
+      where: [{ field: "email", value: email }],
+    });
+
+    // Duplicate check: if the account does not exist yet, report it so the
+    // caller can create it. Skip any creation here.
+    if (!existing) {
+      return { existed: false, isAdmin: false };
+    }
+
+    const roles = rolesFromAuthRoleField(existing.role);
+    if (!roles.includes("admin")) {
+      await adapter.update({
+        model: "user",
+        where: [{ field: "email", value: email }],
+        update: { role: Array.from(new Set([...roles, "admin"])).join(",") },
+      });
+    }
+
+    return { existed: true, isAdmin: true };
+  },
+});

--- a/packages/backend/convex/functions/devAuth.ts
+++ b/packages/backend/convex/functions/devAuth.ts
@@ -23,23 +23,24 @@ function assertLocalDeployment() {
     siteUrl.startsWith("http://127.0.0.1");
   if (!isLocal) {
     throw new ConvexError(
-      "ensureDevAdmin is only available on local development deployments",
+      "ensureDevAccount is only available on local development deployments",
     );
   }
 }
 
 /**
- * Dev-only helper used by the `/api/dev-login` route. Looks up a Better Auth
- * user by email (duplicate check) and, if it exists, ensures it has the "admin"
- * role. Account *creation* is intentionally handled by the app route via the
- * normal Better Auth sign-up endpoint so the browser session cookie is set.
+ * Dev-only helper used by the `/api/dev-login/*` routes. Looks up a Better Auth
+ * user by email (duplicate check) and, when `admin` is requested, ensures the
+ * account has the "admin" role. Account *creation* is intentionally handled by
+ * the app route via the normal Better Auth sign-up endpoint so the browser
+ * session cookie is set.
  *
  * Protected by `backendMutation` (requires INTERNAL_CONVEX_SECRET) and gated to
  * local deployments only.
  */
-export const ensureDevAdmin = backendMutation({
-  args: { email: v.string() },
-  handler: async (ctx, { email }) => {
+export const ensureDevAccount = backendMutation({
+  args: { email: v.string(), admin: v.boolean() },
+  handler: async (ctx, { email, admin }) => {
     assertLocalDeployment();
 
     const auth = initAuth(ctx);
@@ -61,7 +62,7 @@ export const ensureDevAdmin = backendMutation({
     }
 
     const roles = rolesFromAuthRoleField(existing.role);
-    if (!roles.includes("admin")) {
+    if (admin && !roles.includes("admin")) {
       await adapter.update({
         model: "user",
         where: [{ field: "email", value: email }],
@@ -69,6 +70,6 @@ export const ensureDevAdmin = backendMutation({
       });
     }
 
-    return { existed: true, isAdmin: true };
+    return { existed: true, isAdmin: admin || roles.includes("admin") };
   },
 });

--- a/scripts/dev/cloud-local-backend.sh
+++ b/scripts/dev/cloud-local-backend.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# cloud-local-backend.sh
+#
+# Brings up a local (anonymous) Convex backend for Cloud Agent / local development
+# and syncs the relevant secrets onto that deployment so auth, billing and the AI
+# tools work end to end.
+#
+# This is intended for ephemeral dev environments (e.g. Cursor Cloud Agents) where:
+#   * Node 24 + pnpm are already installed (see AGENTS.md).
+#   * The real credentials are present in the *process environment* as injected
+#     secrets (OPENAI_API_KEY, STRIPE_SECRET_KEY, INTERNAL_CONVEX_SECRET, ...).
+#
+# It is idempotent: re-running it is safe. If a backend is already serving on
+# :3210 it only re-syncs env vars.
+#
+# Usage:  bash scripts/dev/cloud-local-backend.sh
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="$REPO_ROOT/packages/backend"
+DATA_DIR="$BACKEND_DIR/.convex/local/default"
+CONVEX_URL="http://127.0.0.1:3210"
+CONVEX_SITE_URL="http://127.0.0.1:3211"
+
+log() { printf '\033[36m[local-convex]\033[0m %s\n' "$*"; }
+
+backend_healthy() { curl -sf -o /dev/null "$CONVEX_URL/version"; }
+
+# 1. Spin up the local deployment + deploy functions if nothing is serving yet.
+#    `convex dev --once` is non-blocking: it deploys schema/functions and exits.
+#    `--codegen disable` avoids regenerating convex/tsconfig.json, which otherwise
+#    breaks `pnpm lint` (see AGENTS.md).
+if backend_healthy; then
+  log "Convex backend already serving on $CONVEX_URL"
+else
+  log "Deploying functions to a fresh local deployment (convex dev --once)..."
+  ( cd "$BACKEND_DIR" && CONVEX_AGENT_MODE=anonymous pnpm exec convex dev --once --codegen disable )
+
+  log "Starting the persistent local Convex backend..."
+  BIN="$(ls -t "$HOME"/.cache/convex/binaries/*/convex-local-backend 2>/dev/null | head -1)"
+  if [[ -z "${BIN:-}" || ! -x "$BIN" ]]; then
+    echo "Could not find the convex-local-backend binary under ~/.cache/convex/binaries" >&2
+    exit 1
+  fi
+  INSTANCE_SECRET="$(python3 -c "import json;print(json.load(open('$DATA_DIR/config.json'))['instanceSecret'])")"
+  ( cd "$DATA_DIR" && nohup "$BIN" \
+      --port 3210 --site-proxy-port 3211 \
+      --instance-name anonymous-agent \
+      --instance-secret "$INSTANCE_SECRET" \
+      --local-storage convex_local_storage \
+      convex_local_backend.sqlite3 > /tmp/convex-backend.log 2>&1 & )
+
+  log "Waiting for the backend to become healthy..."
+  for _ in $(seq 1 30); do backend_healthy && break; sleep 1; done
+  backend_healthy || { echo "Convex backend failed to start; see /tmp/convex-backend.log" >&2; exit 1; }
+fi
+
+# 2. Sync secrets from the process environment onto the Convex deployment.
+ADMIN_KEY="$(python3 -c "import json;print(json.load(open('$DATA_DIR/config.json'))['adminKey'])")"
+
+set_env() {
+  local name="$1" value="$2"
+  [[ -n "$value" ]] || { log "skip $name (not set in environment)"; return 0; }
+  ( cd "$BACKEND_DIR" && pnpm exec convex env set "$name" "$value" \
+      --url "$CONVEX_URL" --admin-key "$ADMIN_KEY" >/dev/null )
+  log "set $name"
+}
+
+log "Syncing secrets onto the local Convex deployment..."
+set_env INTERNAL_CONVEX_SECRET "${INTERNAL_CONVEX_SECRET:-}"
+set_env AUTH_SECRET "${AUTH_SECRET:-}"
+set_env AUTH_GITHUB_ID "${AUTH_GITHUB_ID:-}"
+set_env AUTH_GITHUB_SECRET "${AUTH_GITHUB_SECRET:-}"
+set_env AUTH_GOOGLE_ID "${AUTH_GOOGLE_ID:-}"
+set_env AUTH_GOOGLE_SECRET "${AUTH_GOOGLE_SECRET:-}"
+set_env SILO_URL "${SILO_URL:-}"
+set_env SILO_TOKEN "${SILO_TOKEN:-}"
+set_env SILO_CDN "${SILO_CDN:-${VITE_SILO_CDN:-}}"
+set_env OPENAI_API_KEY "${OPENAI_API_KEY:-}"
+set_env OPENROUTER_API_KEY "${OPENROUTER_API_KEY:-}"
+set_env GOOGLE_VERTEX_API_KEY "${GOOGLE_VERTEX_API_KEY:-}"
+set_env ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
+set_env AA_API_KEY "${AA_API_KEY:-}"
+set_env EXA_API_KEY "${EXA_API_KEY:-}"
+set_env E2B_API_KEY "${E2B_API_KEY:-}"
+set_env STRIPE_SECRET_KEY "${STRIPE_SECRET_KEY:-}"
+set_env STRIPE_WEBHOOK_SECRET "${STRIPE_WEBHOOK_SECRET:-}"
+set_env STRIPE_PLUS_PRICE_ID "${STRIPE_PLUS_PRICE_ID:-}"
+set_env STRIPE_PRO_PRICE_ID "${STRIPE_PRO_PRICE_ID:-}"
+set_env STRIPE_CREDIT_TOP_UP_PRODUCT_ID "${STRIPE_CREDIT_TOP_UP_PRODUCT_ID:-}"
+set_env CLOUDFLARE_ACCOUNT_ID "${CLOUDFLARE_ACCOUNT_ID:-}"
+set_env CLOUDFLARE_API_KEY "${CLOUDFLARE_API_KEY:-}"
+set_env DOCUMENT_CONVERTER_URL "${DOCUMENT_CONVERTER_URL:-}"
+set_env DOCUMENT_CONVERTER_BASIC_AUTH "${DOCUMENT_CONVERTER_BASIC_AUTH:-}"
+set_env DOCUMENT_CONVERTER_TIMEOUT_MS "${DOCUMENT_CONVERTER_TIMEOUT_MS:-}"
+# SITE_URL drives Better Auth cookies/redirects; use the injected value (the local
+# app origin). Falls back to the dev app origin built from the dev port if unset.
+set_env SITE_URL "${SITE_URL:-http://localhost:${APP_PORT:-3712}}"
+
+# convex codegen may recreate convex/tsconfig.json which breaks `pnpm lint`; drop it.
+rm -f "$BACKEND_DIR/convex/tsconfig.json"
+
+log "Done. Convex API: $CONVEX_URL  | HTTP actions: $CONVEX_SITE_URL"
+log "Point the app at these via VITE_CONVEX_URL / VITE_CONVEX_SITE_URL (already in .env)."

--- a/scripts/dev/cloud-local-backend.sh
+++ b/scripts/dev/cloud-local-backend.sh
@@ -56,6 +56,9 @@ else
   # Fully detach the backend: new session (setsid), stdin from /dev/null and
   # stdout/stderr to a log file, then disown so this script never waits on it
   # (otherwise piping this script's output, e.g. `... | tail`, would hang).
+  # NOTE: convex-local-backend has no env-var or file-based alternative for
+  # --instance-secret (it's a plain clap `long` arg with no `env` attribute,
+  # and --instance-name requires it to be passed), so it must be passed on argv.
   ( cd "$DATA_DIR" && setsid "$BIN" \
       --port 3210 --site-proxy-port 3211 \
       --instance-name anonymous-agent \
@@ -77,8 +80,11 @@ set_env() {
   [[ -n "$value" ]] || { log "skip $name (not set in environment)"; return 0; }
   # Pass the value via stdin (supported by `convex env set`) so secrets don't
   # appear in argv / process listings.
-  ( cd "$BACKEND_DIR" && printf '%s' "$value" | pnpm exec convex env set "$name" \
-      --url "$CONVEX_URL" --admin-key "$ADMIN_KEY" >/dev/null )
+  # Pass URL and admin key via environment variables to avoid exposing the admin
+  # key in process listings.
+  ( cd "$BACKEND_DIR" && export CONVEX_SELF_HOSTED_URL="$CONVEX_URL" \
+      CONVEX_SELF_HOSTED_ADMIN_KEY="$ADMIN_KEY" && \
+      printf '%s' "$value" | pnpm exec convex env set "$name" >/dev/null )
   log "set $name"
 }
 

--- a/scripts/dev/cloud-local-backend.sh
+++ b/scripts/dev/cloud-local-backend.sh
@@ -39,7 +39,11 @@ else
   ( cd "$BACKEND_DIR" && CONVEX_AGENT_MODE=anonymous pnpm exec convex dev --once --codegen disable )
 
   log "Starting the persistent local Convex backend..."
-  BIN="$(ls -t "$HOME"/.cache/convex/binaries/*/convex-local-backend 2>/dev/null | head -1)"
+  # Pick the newest backend binary. `find` (unlike `ls -t`) doesn't abort under
+  # `set -e` when nothing matches and is safe with unusual filenames (SC2012).
+  BIN="$(find "$HOME/.cache/convex/binaries" -maxdepth 2 -type f \
+      -name convex-local-backend -printf '%T@ %p\n' 2>/dev/null \
+      | sort -rn | head -1 | cut -d' ' -f2-)"
   if [[ -z "${BIN:-}" || ! -x "$BIN" ]]; then
     echo "Could not find the convex-local-backend binary under ~/.cache/convex/binaries" >&2
     exit 1
@@ -67,7 +71,9 @@ ADMIN_KEY="$(python3 -c "import json;print(json.load(open('$DATA_DIR/config.json
 set_env() {
   local name="$1" value="$2"
   [[ -n "$value" ]] || { log "skip $name (not set in environment)"; return 0; }
-  ( cd "$BACKEND_DIR" && pnpm exec convex env set "$name" "$value" \
+  # Pass the value via stdin (supported by `convex env set`) so secrets don't
+  # appear in argv / process listings.
+  ( cd "$BACKEND_DIR" && printf '%s' "$value" | pnpm exec convex env set "$name" \
       --url "$CONVEX_URL" --admin-key "$ADMIN_KEY" >/dev/null )
   log "set $name"
 }
@@ -106,5 +112,25 @@ set_env SITE_URL "${SITE_URL:-http://localhost:${APP_PORT:-3712}}"
 # convex codegen may recreate convex/tsconfig.json which breaks `pnpm lint`; drop it.
 rm -f "$BACKEND_DIR/convex/tsconfig.json"
 
+# Ensure the web app can find the local backend. Without these, `pnpm dev` throws
+# "VITE_CONVEX_URL is not set" on a fresh checkout. Only append if missing so we
+# never clobber an existing value.
+ensure_env_var() {
+  local name="$1" value="$2" env_file="$REPO_ROOT/.env"
+  if [[ ! -f "$env_file" ]]; then
+    if [[ -f "$REPO_ROOT/.env.example" ]]; then
+      cp "$REPO_ROOT/.env.example" "$env_file"
+    else
+      : > "$env_file"
+    fi
+  fi
+  if ! grep -qE "^${name}=" "$env_file"; then
+    printf '%s="%s"\n' "$name" "$value" >> "$env_file"
+    log "added $name to .env"
+  fi
+}
+ensure_env_var VITE_CONVEX_URL "$CONVEX_URL"
+ensure_env_var VITE_CONVEX_SITE_URL "$CONVEX_SITE_URL"
+
 log "Done. Convex API: $CONVEX_URL  | HTTP actions: $CONVEX_SITE_URL"
-log "Point the app at these via VITE_CONVEX_URL / VITE_CONVEX_SITE_URL (already in .env)."
+log "Web app reads these from .env via VITE_CONVEX_URL / VITE_CONVEX_SITE_URL."

--- a/scripts/dev/cloud-local-backend.sh
+++ b/scripts/dev/cloud-local-backend.sh
@@ -41,9 +41,13 @@ else
   log "Starting the persistent local Convex backend..."
   # Pick the newest backend binary. `find` (unlike `ls -t`) doesn't abort under
   # `set -e` when nothing matches and is safe with unusual filenames (SC2012).
-  BIN="$(find "$HOME/.cache/convex/binaries" -maxdepth 2 -type f \
-      -name convex-local-backend -printf '%T@ %p\n' 2>/dev/null \
-      | sort -rn | head -1 | cut -d' ' -f2-)"
+  if [[ -d "$HOME/.cache/convex/binaries" ]]; then
+    BIN="$(find "$HOME/.cache/convex/binaries" -maxdepth 2 -type f \
+        -name convex-local-backend -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-)"
+  else
+    BIN=""
+  fi
   if [[ -z "${BIN:-}" || ! -x "$BIN" ]]; then
     echo "Could not find the convex-local-backend binary under ~/.cache/convex/binaries" >&2
     exit 1

--- a/scripts/dev/cloud-local-backend.sh
+++ b/scripts/dev/cloud-local-backend.sh
@@ -45,12 +45,16 @@ else
     exit 1
   fi
   INSTANCE_SECRET="$(python3 -c "import json;print(json.load(open('$DATA_DIR/config.json'))['instanceSecret'])")"
-  ( cd "$DATA_DIR" && nohup "$BIN" \
+  # Fully detach the backend: new session (setsid), stdin from /dev/null and
+  # stdout/stderr to a log file, then disown so this script never waits on it
+  # (otherwise piping this script's output, e.g. `... | tail`, would hang).
+  ( cd "$DATA_DIR" && setsid "$BIN" \
       --port 3210 --site-proxy-port 3211 \
       --instance-name anonymous-agent \
       --instance-secret "$INSTANCE_SECRET" \
       --local-storage convex_local_storage \
-      convex_local_backend.sqlite3 > /tmp/convex-backend.log 2>&1 & )
+      convex_local_backend.sqlite3 </dev/null >/tmp/convex-backend.log 2>&1 & )
+  disown -a 2>/dev/null || true
 
   log "Waiting for the backend to become healthy..."
   for _ in $(seq 1 30); do backend_healthy && break; sleep 1; done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Redux Chat monorepo to run end-to-end in a Cursor Cloud Agent VM, documents the non-obvious startup steps, and adds dev-only auto-login routes for seeded user/admin accounts.

- Adds `AGENTS.md` (`## Cursor Cloud specific instructions`): Node 24 PATH gotcha, service startup, local Convex backend + injected-secret sync, a `pnpm lint` gotcha, pre-existing test failures, and the dev-login routes.
- Adds `scripts/dev/cloud-local-backend.sh`: idempotent helper that spins up the anonymous **local Convex backend** (`convex dev --once` to deploy + a persistent backend process to serve) and syncs injected secrets onto the deployment.
- Adds dev-only auto-login routes:
  - **`GET /api/dev-login/user`** → provisions/logs in a normal user (`dev-user@local.test`).
  - **`GET /api/dev-login/admin`** → provisions/logs in an admin (`dev-admin@local.test`).
  - **`GET /api/dev-login`** → redirects to `/api/dev-login/admin`.
  - Each account route **checks for an existing user first and skips creation if one exists**, signs in (session cookie), and redirects to `/`.
  - Implemented in `apps/tanstack-start/src/routes/api/dev-login/` + shared helper `apps/tanstack-start/src/server/dev-login.ts` + `ensureDevAccount` (`packages/backend/convex/functions/devAuth.ts`).

## Security gating for the dev-login routes
Triple-gated, do not loosen:
- Routes return 404 unless `NODE_ENV !== "production"`.
- `ensureDevAccount` requires `INTERNAL_CONVEX_SECRET` (via the existing `backendMutation` wrapper).
- `ensureDevAccount` refuses unless `SITE_URL` is a local origin.

## Verification

- ✅ `pnpm typecheck`
- ✅ `pnpm lint` / `pnpm lint:ws` (after removing the convex-generated `convex/tsconfig.json`, see AGENTS.md)
- ⚠️ `pnpm test` — 77/78 pass; 2 pre-existing `@redux/backend` failures unrelated to setup.
- ✅ Hello-world: email/password sign-up → authenticated chat → AI reply.
- ✅ Routes: `/api/dev-login` → `302` → `/api/dev-login/admin`; `/user` and `/admin` → `303` → `/` with session cookie. `ensureDevAccount` returns `isAdmin:false` for the user and `isAdmin:true` for the admin. Duplicate calls skip creation (idempotent).
- ✅ Browser: `/api/dev-login/user` logs in as `Dev User` and is **blocked** from `/admin`; `/api/dev-login/admin` logs in as `Dev Admin` and `/admin` loads.

### Dev-login user vs admin demo
[dev_login_user_vs_admin_demo.mp4](https://cursor.com/agents/bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_login_user_vs_admin_demo.mp4)

[Logged in as Dev User](https://cursor.com/agents/bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_login_user_account.webp)
[Admin dashboard via dev-login/admin](https://cursor.com/agents/bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_login_admin_dashboard.webp)

### Hello-world (sign-up + AI chat)
[redux_chat_signup_and_ai_chat_demo.mp4](https://cursor.com/agents/bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredux_chat_signup_and_ai_chat_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdb7a1fa-a1be-49c2-ad5d-4f9c38604214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dev-only login endpoints with separate `/api/dev-login/user` and `/api/dev-login/admin` entry points, plus a redirecting `/api/dev-login`.
  * Implemented automatic dev account provisioning and admin role setup before sign-in.
* **Bug Fixes**
  * Ensured the dev login flow is disabled in production.
* **Documentation**
  * Added comprehensive “Cursor Cloud” setup and verification guidance for the Redux Chat monorepo, including local environment and config expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->