### PR TITLE
Fix Anthropic adaptive thinking options

### DIFF
--- a/apps/tanstack-start/src/routes/api/chat/index.ts
+++ b/apps/tanstack-start/src/routes/api/chat/index.ts
@@ -120,6 +120,7 @@ const requestBody = z.object({
 
 type ChatRequestMessage = z.infer<typeof requestBody>["messages"][number];
 type AiSdkReasoning = "none" | "low" | "medium" | "high";
+type AnthropicEffort = "low" | "medium" | "high";
 const MIN_GENERATION_CREDIT_FLOOR = 10;
 type StreamTextProviderOptions = NonNullable<
   Parameters<typeof streamText>[0]["providerOptions"]
@@ -127,16 +128,27 @@ type StreamTextProviderOptions = NonNullable<
 
 function resolveProviderOptions(
   runtimeProviderKey: string,
+  reasoning: AiSdkReasoning | undefined,
 ): StreamTextProviderOptions | undefined {
   if (runtimeProviderKey === "anthropic") {
     return {
       anthropic: {
         cacheControl: { type: "ephemeral" },
+        ...(reasoning && reasoning !== "none"
+          ? {
+              thinking: { type: "adaptive" },
+              effort: reasoning satisfies AnthropicEffort,
+            }
+          : {}),
       } satisfies AnthropicLanguageModelOptions,
     };
   }
 
   return undefined;
+}
+
+function shouldUseGenericReasoning(runtimeProviderKey: string): boolean {
+  return runtimeProviderKey !== "anthropic";
 }
 
 function resolveReasoningParam(
@@ -1152,7 +1164,10 @@ export const Route = createFileRoute("/api/chat/")({
           const runtimeProviderKey =
             resolvedModel.route.behavior.runtimeProviderKey ??
             resolvedModel.route.provider;
-          const providerOptions = resolveProviderOptions(runtimeProviderKey);
+          const providerOptions = resolveProviderOptions(
+            runtimeProviderKey,
+            reasoning,
+          );
           const messagesWithAttachments = await materializeAttachmentsForRoute(
             resolvedModel.route,
             messages,
@@ -1240,7 +1255,9 @@ export const Route = createFileRoute("/api/chat/")({
             model: tracedModel,
             system: systemPrompt,
             messages: modelMessages,
-            ...(reasoning ? { reasoning } : {}),
+            ...(reasoning && shouldUseGenericReasoning(runtimeProviderKey)
+              ? { reasoning }
+              : {}),
             ...(providerOptions ? { providerOptions } : {}),
             abortSignal: abortController.signal,
             tools: toolRuntime.tools,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route Anthropic reasoning levels through provider options using adaptive thinking and effort
- Avoid sending the generic AI SDK `reasoning` parameter for Anthropic models so Claude Sonnet 5 does not receive `thinking.type.enabled`
- Preserve existing generic reasoning behavior for non-Anthropic providers

## Testing
- `pnpm -F @redux/tanstack-start typecheck`
- `NODE_OPTIONS=--experimental-strip-types pnpm -F @redux/tanstack-start lint` (passes with one unrelated warning in `apps/tanstack-start/src/server/ai/telemetry.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54455439-43a1-4f1f-8637-7295a7f442cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54455439-43a1-4f1f-8637-7295a7f442cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

