### PR TITLE
Improve client navigation cache behavior

### DIFF
--- a/apps/tanstack-start/src/components/chat/chat-message-list.tsx
+++ b/apps/tanstack-start/src/components/chat/chat-message-list.tsx
@@ -28,6 +28,7 @@ interface ChatMessageListProps {
   convexUIMessages: ChatMessageWithThreadMetadata[];
   setOptimisticMessage: (m: UIMessage | undefined) => void;
   settings: ComponentProps<typeof EmptyChat>["settings"];
+  settingsReady: ComponentProps<typeof EmptyChat>["settingsReady"];
   status: string;
   messageStatsMap: Map<string, MessageStats>;
   resolvedMessageAttachments: Record<string, ResolvedAttachment>;
@@ -52,6 +53,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   convexUIMessages,
   setOptimisticMessage,
   settings,
+  settingsReady,
   status,
   messageStatsMap,
   resolvedMessageAttachments,
@@ -79,6 +81,7 @@ export const ChatMessageList = memo(function ChatMessageList({
             convexMessages={convexUIMessages}
             setOptimisticMessage={setOptimisticMessage}
             settings={settings}
+            settingsReady={settingsReady}
           />
         )}
       </div>

--- a/apps/tanstack-start/src/components/chat/empty.tsx
+++ b/apps/tanstack-start/src/components/chat/empty.tsx
@@ -12,15 +12,21 @@ import { submitMessage } from "@/components/chat/use-submit-message";
 
 interface SuggestionCardProps {
   text: string;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
-const SuggestionCard = ({ text, onClick }: SuggestionCardProps) => {
+const SuggestionCard = ({
+  text,
+  disabled = false,
+  onClick,
+}: SuggestionCardProps) => {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="border-border bg-card hover:bg-muted/50 text-foreground rounded-xl border px-4 py-3 text-left text-sm transition-colors"
+      disabled={disabled}
+      className="border-border bg-card hover:bg-muted/50 text-foreground disabled:text-muted-foreground disabled:hover:bg-card rounded-xl border px-4 py-3 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-60"
     >
       {text}
     </button>
@@ -39,6 +45,7 @@ interface EmptyChatProps {
   clientId: string;
   convexMessages: UIMessage[];
   settings: MessageSettings;
+  settingsReady: boolean;
 }
 
 const SUGGESTIONS = [
@@ -118,6 +125,7 @@ export const EmptyChat = ({
   clientId,
   convexMessages,
   settings,
+  settingsReady,
 }: EmptyChatProps) => {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
@@ -126,6 +134,10 @@ export const EmptyChat = ({
   const [greeting, setGreeting] = useState("Hello");
 
   const handleSuggestionClick = async (text: string) => {
+    if (!settingsReady) {
+      return;
+    }
+
     if (isAuthLoading) {
       return;
     }
@@ -178,6 +190,7 @@ export const EmptyChat = ({
             <SuggestionCard
               key={text}
               text={text}
+              disabled={!settingsReady}
               onClick={() => void handleSuggestionClick(text)}
             />
           ))}

--- a/apps/tanstack-start/src/components/chat/index.tsx
+++ b/apps/tanstack-start/src/components/chat/index.tsx
@@ -307,6 +307,7 @@ export function Chat({
                   setOptimisticMessage={setOptimisticMessage}
                   setPreviewFile={handleAttachmentPreview}
                   settings={settings}
+                  settingsReady={settingsReady}
                   status={status}
                 />
               </MessageScrollerContent>

--- a/apps/tanstack-start/src/components/route-navigation-progress.tsx
+++ b/apps/tanstack-start/src/components/route-navigation-progress.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouterState } from "@tanstack/react-router";
+
+export function RouteNavigationProgress() {
+  const isLoading = useRouterState({
+    select: (state) => state.isLoading,
+  });
+
+  if (!isLoading) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden
+      className="fixed inset-x-0 top-0 z-50 h-0.5 overflow-hidden"
+    >
+      <div className="bg-primary h-full w-1/3 animate-pulse rounded-r-full" />
+    </div>
+  );
+}

--- a/apps/tanstack-start/src/components/sidebar/footer.tsx
+++ b/apps/tanstack-start/src/components/sidebar/footer.tsx
@@ -71,10 +71,6 @@ export const AppSidebarFooter = () => {
     });
   };
 
-  const handleOpenSettings = () => {
-    void router.navigate({ to: "/settings" });
-  };
-
   if (!mounted || isPending) {
     return (
       <div className="flex items-center gap-2 p-2">
@@ -139,7 +135,7 @@ export const AppSidebarFooter = () => {
                 <Button
                   variant="ghost"
                   className="w-full justify-start"
-                  onClick={handleOpenSettings}
+                  render={<Link to="/settings" preload="render" />}
                 />
               }
             >
@@ -152,7 +148,7 @@ export const AppSidebarFooter = () => {
                   <Button
                     variant="ghost"
                     className="w-full justify-start"
-                    render={<Link to="/admin" />}
+                    render={<Link to="/admin" preload="render" />}
                   />
                 }
               >
@@ -194,12 +190,12 @@ export const AppSidebarFooter = () => {
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="ml-2 w-68 md:w-54" align="start">
-        <DropdownMenuItem onClick={handleOpenSettings}>
+        <DropdownMenuItem render={<Link to="/settings" preload="render" />}>
           <Settings className="size-4" />
           <span>Settings</span>
         </DropdownMenuItem>
         {isAdmin ? (
-          <DropdownMenuItem render={<Link to="/admin" />}>
+          <DropdownMenuItem render={<Link to="/admin" preload="render" />}>
             <Shield className="size-4" />
             <span>Admin</span>
           </DropdownMenuItem>

--- a/apps/tanstack-start/src/router.tsx
+++ b/apps/tanstack-start/src/router.tsx
@@ -45,6 +45,10 @@ export function getRouter() {
   const router = createRouter({
     routeTree,
     defaultPreload: "intent",
+    defaultPreloadStaleTime: 60_000,
+    defaultStaleReloadMode: "background",
+    defaultStaleTime: 60_000,
+    defaultGcTime: 10 * 60_000,
     context: { queryClient, convexQueryClient },
     scrollRestoration: true,
     defaultErrorComponent: DefaultRouterError,

--- a/apps/tanstack-start/src/router.tsx
+++ b/apps/tanstack-start/src/router.tsx
@@ -47,8 +47,6 @@ export function getRouter() {
     defaultPreload: "intent",
     defaultPreloadStaleTime: 60_000,
     defaultPendingMs: Infinity,
-    defaultStaleReloadMode: "background",
-    defaultStaleTime: 60_000,
     defaultGcTime: 10 * 60_000,
     context: { queryClient, convexQueryClient },
     scrollRestoration: true,

--- a/apps/tanstack-start/src/router.tsx
+++ b/apps/tanstack-start/src/router.tsx
@@ -46,6 +46,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     defaultPreloadStaleTime: 60_000,
+    defaultPendingMs: Infinity,
     defaultStaleReloadMode: "background",
     defaultStaleTime: 60_000,
     defaultGcTime: 10 * 60_000,

--- a/apps/tanstack-start/src/routes/__root.tsx
+++ b/apps/tanstack-start/src/routes/__root.tsx
@@ -24,6 +24,7 @@ import { Toaster } from "@redux/ui/components/sonner";
 import { ThemeProvider } from "@redux/ui/components/theme";
 import { cn } from "@redux/ui/lib/utils";
 
+import { RouteNavigationProgress } from "@/components/route-navigation-progress";
 import { env } from "@/env";
 import { authClient } from "@/lib/auth/client";
 import { getToken } from "@/lib/auth/server";
@@ -118,6 +119,7 @@ function RootDocument({ children }: { children: ReactNode }) {
           <ChatScrollPreferencesProvider>
             {children}
           </ChatScrollPreferencesProvider>
+          <RouteNavigationProgress />
           {AppTanStackDevtools ? (
             <ClientOnly>
               <Suspense fallback={null}>

--- a/apps/tanstack-start/src/routes/_app.tsx
+++ b/apps/tanstack-start/src/routes/_app.tsx
@@ -84,24 +84,13 @@ function AppLayout() {
     pathname === "/" || desiredChatThreadId !== undefined;
   const chatMatchThreadId = chatMatch?.params.id;
   const chatThreadId = desiredChatThreadId ?? chatMatchThreadId;
-  const homeLoaderData = homeMatch?.loaderData as
-    | {
-        settingsJson?: ChatPreload["settingsJson"];
-      }
-    | undefined;
   const isHomeRoute = homeMatch !== undefined;
   const isPendingChatRoute =
     desiredChatThreadId !== undefined && chatMatchThreadId !== chatThreadId;
   const shouldRenderChatSurface =
     !isPendingChatRoute && (chatThreadId !== undefined || isHomeRoute);
   const chatPreload: ChatPreload | undefined =
-    chatMatchThreadId === chatThreadId
-      ? chatMatch?.loaderData
-      : chatThreadId === undefined
-        ? {
-            settingsJson: homeLoaderData?.settingsJson ?? null,
-          }
-        : undefined;
+    chatMatchThreadId === chatThreadId ? chatMatch?.loaderData : undefined;
 
   return (
     <ChatRouteAdoptionProvider>

--- a/apps/tanstack-start/src/routes/_app.tsx
+++ b/apps/tanstack-start/src/routes/_app.tsx
@@ -22,22 +22,8 @@ import {
   ReasoningLevelSelectorHotkeyRegistration,
   SidebarToggleHotkeyRegistration,
 } from "@/lib/hotkeys";
-import { getSidebarConfig } from "@/server/cookie";
 
 export const Route = createFileRoute("/_app")({
-  beforeLoad: async () => {
-    // const token = await getToken();
-    const sidebarConfig = await getSidebarConfig();
-    const [openState, savedWidth] = sidebarConfig?.split(":") ?? [];
-    const defaultOpen =
-      openState !== undefined ? openState === "true" : undefined;
-    const defaultWidth = savedWidth;
-    return {
-      // token,
-      defaultOpen,
-      defaultWidth,
-    };
-  },
   component: AppLayout,
 });
 
@@ -82,7 +68,6 @@ function useAppDocumentScrollLock() {
 function AppLayout() {
   useAppDocumentScrollLock();
 
-  const { defaultOpen, defaultWidth } = Route.useRouteContext();
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
@@ -104,11 +89,11 @@ function AppLayout() {
         settingsJson?: ChatPreload["settingsJson"];
       }
     | undefined;
+  const isHomeRoute = homeMatch !== undefined;
   const isPendingChatRoute =
     desiredChatThreadId !== undefined && chatMatchThreadId !== chatThreadId;
   const shouldRenderChatSurface =
-    !isPendingChatRoute &&
-    (chatThreadId !== undefined || homeLoaderData !== undefined);
+    !isPendingChatRoute && (chatThreadId !== undefined || isHomeRoute);
   const chatPreload: ChatPreload | undefined =
     chatMatchThreadId === chatThreadId
       ? chatMatch?.loaderData
@@ -120,11 +105,7 @@ function AppLayout() {
 
   return (
     <ChatRouteAdoptionProvider>
-      <SidebarProvider
-        className="h-dvh max-h-dvh min-h-0 overflow-hidden overscroll-none"
-        defaultOpen={defaultOpen}
-        defaultWidth={defaultWidth}
-      >
+      <SidebarProvider className="h-dvh max-h-dvh min-h-0 overflow-hidden overscroll-none">
         <NewChatHotkeyRegistration />
         <ModelSwitcherHotkeyRegistration />
         <ReasoningLevelSelectorHotkeyRegistration />

--- a/apps/tanstack-start/src/routes/_app/index.tsx
+++ b/apps/tanstack-start/src/routes/_app/index.tsx
@@ -1,24 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-
-import { api } from "@redux/backend/convex/_generated/api";
-
-import { fetchAuthMutation } from "@/lib/auth/server";
-
-const loadHomeChat = createServerFn({ method: "GET" }).handler(async () => {
-  const settings = await fetchAuthMutation(
-    api.functions.defaultMessageSettings.getOrCreate,
-    {},
-  ).catch(() => null);
-
-  return {
-    settingsJson: settings ? JSON.stringify(settings) : null,
-  };
-});
 
 export const Route = createFileRoute("/_app/")({
   ssr: false,
-  loader: () => loadHomeChat(),
   component: NewChatPage,
 });
 

--- a/apps/tanstack-start/src/routes/admin.tsx
+++ b/apps/tanstack-start/src/routes/admin.tsx
@@ -51,8 +51,6 @@ export const Route = createFileRoute("/admin")({
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({ to: "/" });
     }
-
-    return {};
   },
   head: () => ({
     meta: [{ title: "Admin | Redux Chat" }],

--- a/apps/tanstack-start/src/routes/admin.tsx
+++ b/apps/tanstack-start/src/routes/admin.tsx
@@ -1,10 +1,5 @@
 import { useState } from "react";
-import {
-  createFileRoute,
-  Outlet,
-  redirect,
-  useRouteContext,
-} from "@tanstack/react-router";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
 import { SidebarProvider } from "@redux/ui/components/sidebar";
 
@@ -18,14 +13,12 @@ import {
   SidebarToggleHotkeyRegistration,
 } from "@/lib/hotkeys";
 import { fetchAdminDashboardAccess } from "@/server/admin/ensure-admin-access";
-import { getSidebarConfig } from "@/server/cookie";
 
 function AdminLayout() {
-  const { defaultOpen, defaultWidth } = useRouteContext({ from: "/admin" });
   const [commandOpen, setCommandOpen] = useState(false);
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen} defaultWidth={defaultWidth}>
+    <SidebarProvider>
       <CommandPanel open={commandOpen} onOpenChange={setCommandOpen} />
       <NewChatHotkeyRegistration />
       <ModelSwitcherHotkeyRegistration />
@@ -53,22 +46,13 @@ export const Route = createFileRoute("/admin")({
       throw redirect({ to: "/auth/sign-in" });
     }
 
-    const sidebarConfig = await getSidebarConfig();
-    const [openState, savedWidth] = sidebarConfig?.split(":") ?? [];
-    const defaultOpen =
-      openState !== undefined ? openState === "true" : undefined;
-    const defaultWidth = savedWidth;
-
     const access = await fetchAdminDashboardAccess();
     if (!access.isAdmin) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({ to: "/" });
     }
 
-    return {
-      defaultOpen,
-      defaultWidth,
-    };
+    return {};
   },
   head: () => ({
     meta: [{ title: "Admin | Redux Chat" }],

--- a/apps/tanstack-start/src/routes/settings.tsx
+++ b/apps/tanstack-start/src/routes/settings.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  createFileRoute,
-  Outlet,
-  useRouteContext,
-} from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 import { SidebarProvider } from "@redux/ui/components/sidebar";
 
@@ -16,14 +12,12 @@ import {
   ReasoningLevelSelectorHotkeyRegistration,
   SidebarToggleHotkeyRegistration,
 } from "@/lib/hotkeys";
-import { getSidebarConfig } from "@/server/cookie";
 
 function SettingsLayout() {
-  const { defaultOpen, defaultWidth } = useRouteContext({ from: "/settings" });
   const [commandOpen, setCommandOpen] = useState(false);
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen} defaultWidth={defaultWidth}>
+    <SidebarProvider>
       <CommandPanel open={commandOpen} onOpenChange={setCommandOpen} />
       <NewChatHotkeyRegistration />
       <ModelSwitcherHotkeyRegistration />
@@ -47,17 +41,5 @@ function SettingsLayout() {
 }
 
 export const Route = createFileRoute("/settings")({
-  beforeLoad: async () => {
-    const sidebarConfig = await getSidebarConfig();
-    const [openState, savedWidth] = sidebarConfig?.split(":") ?? [];
-    const defaultOpen =
-      openState !== undefined ? openState === "true" : undefined;
-    const defaultWidth = savedWidth;
-
-    return {
-      defaultOpen,
-      defaultWidth,
-    };
-  },
   component: SettingsLayout,
 });

--- a/apps/tanstack-start/src/server/cookie.ts
+++ b/apps/tanstack-start/src/server/cookie.ts
@@ -1,8 +1,0 @@
-import { createServerFn } from "@tanstack/react-start";
-import { getCookie } from "@tanstack/react-start/server";
-
-export const getSidebarConfig = createServerFn({ method: "GET" }).handler(
-  () => {
-    return getCookie("sidebar:config") ?? null;
-  },
-);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Preload Settings/Admin route bundles from account menu links while keeping route bundles lazy.
- Remove nonessential server route data fetches for sidebar/home defaults so Settings and home can render client-side.
- Keep auth/admin checks fresh by avoiding broad stale route-data caching.
- Disable the full-page pending screen and add a subtle top loading indicator for cold route transitions.
- Gate empty-chat suggestions on `settingsReady` so saved model/tools/instruction defaults are loaded before a suggestion can submit.

### Walkthrough
[review_fixes_settings_navigation_trimmed.mp4](https://cursor.com/agents/bc-ce9c12b4-fbbc-47cd-9499-6f470dcaff2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview_fixes_settings_navigation_trimmed.mp4)

### Testing
- `pnpm -F @redux/tanstack-start typecheck`
- `pnpm -F @redux/tanstack-start lint` (passes with one pre-existing warning in `src/server/ai/telemetry.ts`)
- `pnpm -F @redux/tanstack-start format`
- `npx react-doctor@latest --verbose --diff`
- `pnpm -F @redux/tanstack-start build`
- Manual browser walkthrough on local Docker + Convex + Vite stack, reviewed via video artifact

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce9c12b4-fbbc-47cd-9499-6f470dcaff2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce9c12b4-fbbc-47cd-9499-6f470dcaff2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Settings/Admin navigation reliability (desktop dropdown and mobile bottom sheet).
  * Pages no longer rely on persisted sidebar defaults loading before rendering.
  * Chat empty-state suggestions are now disabled until message settings are ready, improving consistency during home/chat switching.

* **Performance**
  * Updated router caching/timing defaults to improve navigation responsiveness.
  * More consistent gating of chat-surface rendering to reduce unnecessary transitions.

* **New Features**
  * Added a top progress indicator during route navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->