### PR TITLE
Support static OAuth clients for MCP servers

### DIFF
--- a/apps/tanstack-start/src/components/chat/chat-message-row.tsx
+++ b/apps/tanstack-start/src/components/chat/chat-message-row.tsx
@@ -313,7 +313,11 @@ export const ChatMessageRow = memo(function ChatMessageRow({
               <CardContent className="flex items-start gap-3 px-3">
                 <CircleAlert className="mt-0.5 size-4 shrink-0" />
                 <div className="min-w-0 space-y-1">
-                  <p className="font-medium">Message generation failed</p>
+                  <p className="font-medium">
+                    {message.error?.startsWith("MCP server ")
+                      ? "MCP server error"
+                      : "Message generation failed"}
+                  </p>
                   {message.error && (
                     <p className="text-destructive/80 wrap-break-word">
                       {message.error}

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -56,11 +56,17 @@ interface McpServerDraft {
   url: string;
   transport: McpServerTransport;
   authHeaders: AuthHeaderDraft[];
+  oauthStaticClientInfo: OAuthStaticClientInfoDraft;
 }
 
 interface AuthHeaderDraft {
   name: string;
   value: string;
+}
+
+interface OAuthStaticClientInfoDraft {
+  client_id: string;
+  client_secret: string;
 }
 
 interface DiscoveredTool {
@@ -80,12 +86,20 @@ function createDraft(server: {
   url: string;
   transport?: McpServerTransport;
   authHeaders?: AuthHeaderDraft[];
+  oauthStaticClientInfo?: {
+    client_id: string;
+    client_secret?: string;
+  };
 }): McpServerDraft {
   return {
     name: server.name,
     url: server.url,
     transport: server.transport ?? "http",
     authHeaders: server.authHeaders ?? [],
+    oauthStaticClientInfo: {
+      client_id: server.oauthStaticClientInfo?.client_id ?? "",
+      client_secret: server.oauthStaticClientInfo?.client_secret ?? "",
+    },
   };
 }
 
@@ -103,6 +117,30 @@ function compactAuthHeaders(authHeaders: AuthHeaderDraft[]) {
 
 function serializeAuthHeaders(authHeaders: AuthHeaderDraft[]) {
   return JSON.stringify(compactAuthHeaders(authHeaders));
+}
+
+function compactOAuthStaticClientInfo(
+  clientInfo: OAuthStaticClientInfoDraft,
+) {
+  const client_id = clientInfo.client_id.trim();
+  const client_secret = clientInfo.client_secret.trim();
+
+  if (!client_id && !client_secret) {
+    return undefined;
+  }
+
+  return {
+    client_id,
+    ...(client_secret ? { client_secret } : {}),
+  };
+}
+
+function serializeOAuthStaticClientInfo(
+  clientInfo: OAuthStaticClientInfoDraft | undefined,
+) {
+  return JSON.stringify(
+    clientInfo ? compactOAuthStaticClientInfo(clientInfo) : undefined,
+  );
 }
 
 export function McpSettingsManager() {
@@ -148,6 +186,11 @@ export function McpSettingsManager() {
   const [newAuthHeaders, setNewAuthHeaders] = useReducerState<
     AuthHeaderDraft[]
   >([]);
+  const [newOAuthStaticClientInfo, setNewOAuthStaticClientInfo] =
+    useReducerState<OAuthStaticClientInfoDraft>({
+      client_id: "",
+      client_secret: "",
+    });
   const [showAddForm, setShowAddForm] = useReducerState(false);
   const [savingEnabled, setSavingEnabled] = useReducerState(false);
   const [creating, setCreating] = useReducerState(false);
@@ -213,7 +256,17 @@ export function McpSettingsManager() {
             draft.url !== server.url ||
             draft.transport !== server.transport ||
             serializeAuthHeaders(draft.authHeaders) !==
-              serializeAuthHeaders(authHeaders)
+              serializeAuthHeaders(authHeaders) ||
+            serializeOAuthStaticClientInfo(draft.oauthStaticClientInfo) !==
+              serializeOAuthStaticClientInfo(
+                server.oauthStaticClientInfo
+                  ? {
+                      client_id: server.oauthStaticClientInfo.client_id,
+                      client_secret:
+                        server.oauthStaticClientInfo.client_secret ?? "",
+                    }
+                  : undefined,
+              )
             ? [server.mcpServerId]
             : [];
         }),
@@ -224,16 +277,21 @@ export function McpSettingsManager() {
   const handleCreate = async () => {
     setCreating(true);
     try {
+      const oauthStaticClientInfo = compactOAuthStaticClientInfo(
+        newOAuthStaticClientInfo,
+      );
       await createServer({
         name: newServerName,
         url: newServerUrl,
         transport: newServerTransport,
         authHeaders: compactAuthHeaders(newAuthHeaders),
+        ...(oauthStaticClientInfo ? { oauthStaticClientInfo } : {}),
       });
       setNewServerName("");
       setNewServerUrl("");
       setNewServerTransport("http");
       setNewAuthHeaders([]);
+      setNewOAuthStaticClientInfo({ client_id: "", client_secret: "" });
       setShowAddForm(false);
       toast.success("MCP server added");
     } catch (error) {
@@ -251,6 +309,9 @@ export function McpSettingsManager() {
 
     setSavingId(mcpServerId);
     try {
+      const oauthStaticClientInfo = compactOAuthStaticClientInfo(
+        draft.oauthStaticClientInfo,
+      );
       await updateServer({
         mcpServerId,
         patch: {
@@ -258,6 +319,10 @@ export function McpSettingsManager() {
           url: draft.url,
           transport: draft.transport,
           authHeaders: compactAuthHeaders(draft.authHeaders),
+          oauthStaticClientInfo: oauthStaticClientInfo ?? {
+            client_id: "",
+            client_secret: "",
+          },
         },
       });
       setEditingIds((current) => ({ ...current, [mcpServerId]: false }));
@@ -569,6 +634,12 @@ export function McpSettingsManager() {
                   disabled={creating}
                   idPrefix="new-mcp-server"
                   onChange={setNewAuthHeaders}
+                />
+                <OAuthStaticClientEditor
+                  clientInfo={newOAuthStaticClientInfo}
+                  disabled={creating}
+                  idPrefix="new-mcp-server"
+                  onChange={setNewOAuthStaticClientInfo}
                 />
                 <div className="flex justify-end gap-2">
                   <Button
@@ -909,7 +980,7 @@ export function McpSettingsManager() {
                               variant="outline"
                               size="sm"
                               className="h-7 text-xs"
-                              disabled={isConnectingOAuth}
+                              disabled={isConnectingOAuth || isDirty}
                               onClick={() => handleOAuthConnect(mcpServerId)}
                             >
                               {isConnectingOAuth ? (
@@ -926,6 +997,26 @@ export function McpSettingsManager() {
                             ? "OAuth tokens are configured for this server."
                             : "Connect via OAuth if the server requires authorization."}
                         </p>
+                        <OAuthStaticClientEditor
+                          clientInfo={draft.oauthStaticClientInfo}
+                          disabled={isSaving || isDeleting}
+                          idPrefix={`${mcpServerId}-oauth`}
+                          onChange={(oauthStaticClientInfo) =>
+                            setDrafts((current) => ({
+                              ...current,
+                              [mcpServerId]: {
+                                ...(current[mcpServerId] ??
+                                  createDraft(server)),
+                                oauthStaticClientInfo,
+                              },
+                            }))
+                          }
+                        />
+                        {isDirty ? (
+                          <p className="text-muted-foreground text-xs">
+                            Save changes before starting a new OAuth connection.
+                          </p>
+                        ) : null}
                       </div>
 
                       <div className="flex justify-end">
@@ -1162,6 +1253,71 @@ function ToolPermissionRow({
           </SelectItem>
         </SelectContent>
       </Select>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OAuth Static Client Editor
+// ---------------------------------------------------------------------------
+
+function OAuthStaticClientEditor({
+  clientInfo,
+  disabled,
+  idPrefix,
+  onChange,
+}: {
+  clientInfo: OAuthStaticClientInfoDraft;
+  disabled: boolean;
+  idPrefix: string;
+  onChange: (clientInfo: OAuthStaticClientInfoDraft) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-1.5">
+        <Link2 className="text-muted-foreground size-3.5" />
+        <span className="text-xs font-medium">Static OAuth client</span>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Optional credentials for servers that do not support dynamic client
+        registration, such as GitHub Copilot MCP.
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`${idPrefix}-oauth-client-id`} className="text-xs">
+            Client ID
+          </Label>
+          <Input
+            id={`${idPrefix}-oauth-client-id`}
+            disabled={disabled}
+            placeholder="OAuth app client ID"
+            value={clientInfo.client_id}
+            className="h-8 text-xs"
+            onChange={(e) =>
+              onChange({ ...clientInfo, client_id: e.target.value })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label
+            htmlFor={`${idPrefix}-oauth-client-secret`}
+            className="text-xs"
+          >
+            Client secret
+          </Label>
+          <Input
+            id={`${idPrefix}-oauth-client-secret`}
+            disabled={disabled}
+            placeholder="Optional client secret"
+            type="password"
+            value={clientInfo.client_secret}
+            className="h-8 text-xs"
+            onChange={(e) =>
+              onChange({ ...clientInfo, client_secret: e.target.value })
+            }
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -319,6 +319,8 @@ export function McpSettingsManager() {
           url: draft.url,
           transport: draft.transport,
           authHeaders: compactAuthHeaders(draft.authHeaders),
+          // Send an empty object when fields are cleared so the backend can
+          // distinguish "clear this" from an omitted, unchanged patch field.
           oauthStaticClientInfo: oauthStaticClientInfo ?? {
             client_id: "",
             client_secret: "",
@@ -844,7 +846,7 @@ export function McpSettingsManager() {
                           variant="outline"
                           size="sm"
                           className="h-7 text-xs"
-                          disabled={isConnectingOAuth}
+                          disabled={isConnectingOAuth || isDirty}
                           onClick={() => handleOAuthConnect(mcpServerId)}
                         >
                           {isConnectingOAuth ? (

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -119,9 +119,7 @@ function serializeAuthHeaders(authHeaders: AuthHeaderDraft[]) {
   return JSON.stringify(compactAuthHeaders(authHeaders));
 }
 
-function compactOAuthStaticClientInfo(
-  clientInfo: OAuthStaticClientInfoDraft,
-) {
+function compactOAuthStaticClientInfo(clientInfo: OAuthStaticClientInfoDraft) {
   const client_id = clientInfo.client_id.trim();
   const client_secret = clientInfo.client_secret.trim();
 

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -811,52 +811,59 @@ export function McpSettingsManager() {
 
                   {/* OAuth connect/disconnect (always visible) */}
                   {!isEditing ? (
-                    <div className="flex items-center justify-between">
-                      {server.hasOAuth ? (
-                        <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
-                          <Link2 className="size-3.5 text-blue-500" />
-                          OAuth connected
-                        </span>
-                      ) : (
-                        <span className="text-muted-foreground text-xs">
-                          Not authenticated
-                        </span>
-                      )}
-                      {server.hasOAuth ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs text-red-500 hover:text-red-600"
-                          disabled={isDisconnectingOAuth}
-                          onClick={() =>
-                            void handleOAuthDisconnect(mcpServerId)
-                          }
-                        >
-                          {isDisconnectingOAuth ? (
-                            <Loader2 className="size-3.5 animate-spin" />
-                          ) : (
-                            <Link2Off className="size-3.5" />
-                          )}
-                          Disconnect
-                        </Button>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs"
-                          disabled={isConnectingOAuth || isDirty}
-                          onClick={() => handleOAuthConnect(mcpServerId)}
-                        >
-                          {isConnectingOAuth ? (
-                            <Loader2 className="size-3.5 animate-spin" />
-                          ) : (
-                            <Link2 className="size-3.5" />
-                          )}
-                          Connect with OAuth
-                        </Button>
-                      )}
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center justify-between">
+                        {server.hasOAuth ? (
+                          <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+                            <Link2 className="size-3.5 text-blue-500" />
+                            OAuth connected
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">
+                            Not authenticated
+                          </span>
+                        )}
+                        {server.hasOAuth ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs text-red-500 hover:text-red-600"
+                            disabled={isDisconnectingOAuth}
+                            onClick={() =>
+                              void handleOAuthDisconnect(mcpServerId)
+                            }
+                          >
+                            {isDisconnectingOAuth ? (
+                              <Loader2 className="size-3.5 animate-spin" />
+                            ) : (
+                              <Link2Off className="size-3.5" />
+                            )}
+                            Disconnect
+                          </Button>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            disabled={isConnectingOAuth || isDirty}
+                            onClick={() => handleOAuthConnect(mcpServerId)}
+                          >
+                            {isConnectingOAuth ? (
+                              <Loader2 className="size-3.5 animate-spin" />
+                            ) : (
+                              <Link2 className="size-3.5" />
+                            )}
+                            Connect with OAuth
+                          </Button>
+                        )}
+                      </div>
+                      {isDirty ? (
+                        <p className="text-muted-foreground text-xs">
+                          Save changes before starting a new OAuth connection.
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
 

--- a/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
+++ b/apps/tanstack-start/src/components/settings/mcp-settings-manager.tsx
@@ -1049,71 +1049,63 @@ export function McpSettingsManager() {
                   {hasTools ? (
                     <div className="flex flex-col">
                       {/* Toggle to expand/collapse tools */}
-                      <button
-                        type="button"
-                        className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-1.5 transition-colors"
-                        onClick={() =>
-                          setExpandedIds((current) => ({
-                            ...current,
-                            [mcpServerId]: !current[mcpServerId],
-                          }))
-                        }
-                      >
-                        {isExpanded ? (
-                          <ChevronDown className="text-muted-foreground size-4 shrink-0" />
-                        ) : (
-                          <ChevronRight className="text-muted-foreground size-4 shrink-0" />
-                        )}
-                        <span className="text-xs font-medium">
-                          {toolState.tools.length} tool
-                          {toolState.tools.length !== 1 ? "s" : ""}
-                        </span>
+                      <div className="-mx-1 flex items-center gap-2">
+                        <button
+                          type="button"
+                          className="hover:bg-muted/50 flex flex-1 items-center gap-2 rounded-md px-1 py-1.5 transition-colors"
+                          onClick={() =>
+                            setExpandedIds((current) => ({
+                              ...current,
+                              [mcpServerId]: !current[mcpServerId],
+                            }))
+                          }
+                        >
+                          {isExpanded ? (
+                            <ChevronDown className="text-muted-foreground size-4 shrink-0" />
+                          ) : (
+                            <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+                          )}
+                          <span className="text-xs font-medium">
+                            {toolState.tools.length} tool
+                            {toolState.tools.length !== 1 ? "s" : ""}
+                          </span>
+                        </button>
 
-                        {/* Bulk permission dropdown */}
                         {isExpanded ? (
-                          <div
-                            className="ml-auto"
-                            onClick={(e) => e.stopPropagation()}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ")
-                                e.stopPropagation();
+                          <Select
+                            value={bulkValue ?? ""}
+                            onValueChange={(value) => {
+                              void handleBulkPermission(
+                                mcpServerId,
+                                value as McpToolPermission,
+                                toolState.tools.map((t) => t.name),
+                              );
                             }}
                           >
-                            <Select
-                              value={bulkValue ?? ""}
-                              onValueChange={(value) => {
-                                void handleBulkPermission(
-                                  mcpServerId,
-                                  value as McpToolPermission,
-                                  toolState.tools.map((t) => t.name),
-                                );
-                              }}
+                            <SelectTrigger
+                              size="sm"
+                              className="h-6 gap-1 text-xs"
+                              aria-label="Set all tool permissions"
                             >
-                              <SelectTrigger
-                                size="sm"
-                                className="h-6 gap-1 text-xs"
-                                aria-label="Set all tool permissions"
-                              >
-                                <SelectValue placeholder="Set all" />
-                              </SelectTrigger>
-                              <SelectContent position="popper" align="end">
-                                <SelectItem value="allow">
-                                  <ShieldCheck className="text-emerald-500" />
-                                  Allow all
-                                </SelectItem>
-                                <SelectItem value="ask">
-                                  <ShieldQuestion className="text-yellow-500" />
-                                  Ask all
-                                </SelectItem>
-                                <SelectItem value="deny">
-                                  <ShieldAlert className="text-red-500" />
-                                  Deny all
-                                </SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </div>
+                              <SelectValue placeholder="Set all" />
+                            </SelectTrigger>
+                            <SelectContent position="popper" align="end">
+                              <SelectItem value="allow">
+                                <ShieldCheck className="text-emerald-500" />
+                                Allow all
+                              </SelectItem>
+                              <SelectItem value="ask">
+                                <ShieldQuestion className="text-yellow-500" />
+                                Ask all
+                              </SelectItem>
+                              <SelectItem value="deny">
+                                <ShieldAlert className="text-red-500" />
+                                Deny all
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
                         ) : null}
-                      </button>
+                      </div>
 
                       {/* Tool rows */}
                       {isExpanded ? (

--- a/apps/tanstack-start/src/lib/ai/tools/index.ts
+++ b/apps/tanstack-start/src/lib/ai/tools/index.ts
@@ -83,6 +83,65 @@ interface ToolRuntime {
   mcpToolApproval: Record<string, ToolApprovalStatus>;
 }
 
+function getRuntimeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    const serialized = JSON.stringify(error) as string | undefined;
+    return serialized ?? "Unknown error";
+  } catch {
+    return "Unknown error";
+  }
+}
+
+function formatMcpServerRuntimeError({
+  error,
+  operation,
+  serverName,
+  toolName,
+}: {
+  error: unknown;
+  operation: "connect" | "tool";
+  serverName: string;
+  toolName?: string;
+}) {
+  const detail = getRuntimeErrorMessage(error);
+  const lowerDetail = detail.toLowerCase();
+  const recoveryHint =
+    lowerDetail.includes("authorization") ||
+    lowerDetail.includes("unauthorized") ||
+    lowerDetail.includes("access token") ||
+    lowerDetail.includes("oauth") ||
+    lowerDetail.includes("401") ||
+    lowerDetail.includes("403")
+      ? "Reconnect it with OAuth in Settings > MCP Servers, add the required auth header, or disable this MCP server for the message."
+      : "Check this server in Settings > MCP Servers, or disable it for the message.";
+
+  const action =
+    operation === "connect"
+      ? "failed to connect"
+      : `tool${toolName ? ` "${toolName}"` : ""} failed`;
+
+  return `MCP server "${serverName}" ${action}: ${detail}. ${recoveryHint}`;
+}
+
+function createMcpServerRuntimeError(input: {
+  error: unknown;
+  operation: "connect" | "tool";
+  serverName: string;
+  toolName?: string;
+}) {
+  return new Error(formatMcpServerRuntimeError(input), {
+    cause: input.error,
+  });
+}
+
 const MAX_TOOL_RESULT_STRING_CHARS = 100_000;
 const MAX_TOOL_RESULT_ARRAY_ITEMS = 200;
 const BINARY_SAMPLE_SIZE = 256;
@@ -454,31 +513,46 @@ export async function createToolRuntime(
 
   if (enabledTools.includes("mcpServers")) {
     for (const server of mcpServers) {
-      assertAllowedMcpServerUrl(server.url);
+      let client: Awaited<ReturnType<typeof createMCPClient>> | undefined;
+      let serverTools: Awaited<
+        ReturnType<Awaited<ReturnType<typeof createMCPClient>>["tools"]>
+      >;
+      try {
+        assertAllowedMcpServerUrl(server.url);
 
-      const authProvider = server.oauthTokens
-        ? createChatOAuthProvider(server, async (tokens) => {
-            await onOAuthTokensRefreshed?.(server.mcpServerId, tokens);
-          })
-        : undefined;
+        const authProvider = server.oauthTokens
+          ? createChatOAuthProvider(server, async (tokens) => {
+              await onOAuthTokensRefreshed?.(server.mcpServerId, tokens);
+            })
+          : undefined;
 
-      const client = await createMCPClient({
-        name: `redux-chat-${server.mcpServerId}`,
-        transport: createMcpTransport({
-          url: server.url,
-          transport: server.transport,
-          headers: Object.fromEntries(
-            (server.authHeaders ?? []).map((header) => [
-              header.name,
-              header.value,
-            ]),
-          ),
-          authProvider,
-        }),
-      });
-      mcpClients.push(client);
+        client = await createMCPClient({
+          name: `redux-chat-${server.mcpServerId}`,
+          transport: createMcpTransport({
+            url: server.url,
+            transport: server.transport,
+            headers: Object.fromEntries(
+              (server.authHeaders ?? []).map((header) => [
+                header.name,
+                header.value,
+              ]),
+            ),
+            authProvider,
+          }),
+        });
 
-      const serverTools = await client.tools();
+        serverTools = await client.tools();
+        mcpClients.push(client);
+      } catch (error) {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await client?.close().catch(() => {});
+        throw createMcpServerRuntimeError({
+          error,
+          operation: "connect",
+          serverName: server.name,
+        });
+      }
+
       const prefix = toToolKeyPrefix(server.name);
       const billingKey = `mcp:${prefix}` satisfies ToolBillingKey;
       const permissions = server.toolPermissions ?? {};
@@ -499,6 +573,13 @@ export async function createToolRuntime(
           toolDefinition,
           billingKey,
           toolUsageCounts,
+          (error) =>
+            createMcpServerRuntimeError({
+              error,
+              operation: "tool",
+              serverName: server.name,
+              toolName,
+            }),
         );
 
         if (permission === "ask") {
@@ -587,6 +668,7 @@ function instrumentTool(
   definition: ToolSet[string],
   billingKey: string,
   usageCounts: Map<string, number>,
+  mapError?: (error: unknown) => Error,
 ) {
   const candidate = definition as ToolSet[string] & {
     execute?: (...args: unknown[]) => unknown;
@@ -600,7 +682,11 @@ function instrumentTool(
     ...candidate,
     execute: async (...args: unknown[]) => {
       usageCounts.set(billingKey, (usageCounts.get(billingKey) ?? 0) + 1);
-      return toConvexSafeValue(await execute(...args)) ?? null;
+      try {
+        return toConvexSafeValue(await execute(...args)) ?? null;
+      } catch (error) {
+        throw mapError?.(error) ?? error;
+      }
     },
   } satisfies ToolSet[string];
 }

--- a/apps/tanstack-start/src/routes/api/mcp/oauth/authorize.ts
+++ b/apps/tanstack-start/src/routes/api/mcp/oauth/authorize.ts
@@ -47,6 +47,7 @@ export const Route = createFileRoute("/api/mcp/oauth/authorize")({
 
         const provider = new ServerMcpOAuthProvider({
           callbackRedirectUrl: callbackUrl,
+          preloadedClientInfo: server.oauthStaticClientInfo,
         });
 
         try {

--- a/apps/tanstack-start/src/server/ai/telemetry.ts
+++ b/apps/tanstack-start/src/server/ai/telemetry.ts
@@ -41,7 +41,6 @@ export function withPostHogTracing(
   const ph = getPostHogClient();
   if (!ph) return model;
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
   return withTracing(model as WrappableModel, ph, {
     posthogDistinctId: distinctId,
   });

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -210,7 +210,7 @@ describe("functions/mcpServers", () => {
         name: "GitHub MCP",
         url: "https://api.githubcopilot.com/mcp/",
         oauthStaticClientInfo: {
-          client_id: `${"a".repeat(513)}`,
+          client_id: "a".repeat(513),
         },
       }),
     ).rejects.toThrow("OAuth client ID is too long");

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -107,6 +107,88 @@ describe("functions/mcpServers", () => {
     ]);
   });
 
+  it("keeps static OAuth client credentials after disconnecting tokens", async () => {
+    const t = authedTest();
+
+    const { mcpServerId } = await t.mutation(api.functions.mcpServers.create, {
+      name: "GitHub MCP",
+      url: "https://api.githubcopilot.com/mcp/",
+      oauthStaticClientInfo: {
+        client_id: " github-client-id ",
+        client_secret: " github-client-secret ",
+      },
+    });
+
+    await expect(t.query(api.functions.mcpServers.list)).resolves.toEqual([
+      {
+        mcpServerId,
+        name: "GitHub MCP",
+        url: "https://api.githubcopilot.com/mcp/",
+        transport: "http",
+        toolPermissions: {},
+        hasOAuth: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    await expect(
+      t.query(api.functions.mcpServers.listConfigured),
+    ).resolves.toMatchObject([
+      {
+        mcpServerId,
+        oauthStaticClientInfo: {
+          client_id: "github-client-id",
+          client_secret: "github-client-secret",
+        },
+      },
+    ]);
+
+    await t.mutation(api.functions.mcpServers.createOAuthFlow, {
+      mcpServerId,
+      flowId: "flow-1",
+      serverUrl: "https://api.githubcopilot.com/mcp/",
+      codeVerifier: "code-verifier",
+      state: "state-1",
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+      authorizationServerUrl: "https://github.com/login/oauth",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+    await t.mutation(api.functions.mcpServers.saveOAuthTokens, {
+      mcpServerId,
+      flowId: "flow-1",
+      tokens: {
+        access_token: "access-token",
+        token_type: "Bearer",
+      },
+      clientInfo: {
+        client_id: "github-client-id",
+        client_secret: "github-client-secret",
+      },
+      serverMetadata: {
+        authorizationServerUrl: "https://github.com/login/oauth",
+        tokenEndpoint: "https://github.com/login/oauth/access_token",
+      },
+    });
+    await t.mutation(api.functions.mcpServers.clearOAuthTokens, {
+      mcpServerId,
+    });
+
+    await expect(
+      t.query(api.functions.mcpServers.getByIds, {
+        serverIds: [mcpServerId],
+      }),
+    ).resolves.toMatchObject([
+      {
+        mcpServerId,
+        oauthStaticClientInfo: {
+          client_id: "github-client-id",
+          client_secret: "github-client-secret",
+        },
+      },
+    ]);
+  });
+
   it("rejects unsafe or duplicate auth headers", async () => {
     const t = authedTest();
 

--- a/packages/backend/convex/functions/mcpServers.test.ts
+++ b/packages/backend/convex/functions/mcpServers.test.ts
@@ -189,6 +189,149 @@ describe("functions/mcpServers", () => {
     ]);
   });
 
+  it("rejects invalid static OAuth client credentials", async () => {
+    const t = authedTest();
+
+    await expect(
+      t.mutation(api.functions.mcpServers.create, {
+        name: "GitHub MCP",
+        url: "https://api.githubcopilot.com/mcp/",
+        oauthStaticClientInfo: {
+          client_id: "",
+          client_secret: "secret",
+        },
+      }),
+    ).rejects.toThrow(
+      "OAuth client ID is required when a client secret is provided",
+    );
+
+    await expect(
+      t.mutation(api.functions.mcpServers.create, {
+        name: "GitHub MCP",
+        url: "https://api.githubcopilot.com/mcp/",
+        oauthStaticClientInfo: {
+          client_id: `${"a".repeat(513)}`,
+        },
+      }),
+    ).rejects.toThrow("OAuth client ID is too long");
+
+    await expect(
+      t.mutation(api.functions.mcpServers.create, {
+        name: "GitHub MCP",
+        url: "https://api.githubcopilot.com/mcp/",
+        oauthStaticClientInfo: {
+          client_id: "client-id",
+          client_secret: "s".repeat(4097),
+        },
+      }),
+    ).rejects.toThrow("OAuth client secret is too long");
+
+    await expect(
+      t.mutation(api.functions.mcpServers.create, {
+        name: "GitHub MCP",
+        url: "https://api.githubcopilot.com/mcp/",
+        oauthStaticClientInfo: {
+          client_id: "client\nid",
+        },
+      }),
+    ).rejects.toThrow("OAuth client credentials cannot contain new lines");
+  });
+
+  it("clears tokens and pending OAuth flows when OAuth identity changes", async () => {
+    const t = authedTest();
+
+    const { mcpServerId } = await t.mutation(api.functions.mcpServers.create, {
+      name: "GitHub MCP",
+      url: "https://api.githubcopilot.com/mcp/",
+      oauthStaticClientInfo: {
+        client_id: "github-client-id",
+        client_secret: "github-client-secret",
+      },
+    });
+
+    await t.mutation(api.functions.mcpServers.createOAuthFlow, {
+      mcpServerId,
+      flowId: "completed-flow",
+      serverUrl: "https://api.githubcopilot.com/mcp/",
+      codeVerifier: "code-verifier",
+      state: "state-1",
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+      authorizationServerUrl: "https://github.com/login/oauth",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+    await t.mutation(api.functions.mcpServers.saveOAuthTokens, {
+      mcpServerId,
+      flowId: "completed-flow",
+      tokens: {
+        access_token: "access-token",
+        token_type: "Bearer",
+      },
+      clientInfo: {
+        client_id: "github-client-id",
+        client_secret: "github-client-secret",
+      },
+      serverMetadata: {
+        authorizationServerUrl: "https://github.com/login/oauth",
+        tokenEndpoint: "https://github.com/login/oauth/access_token",
+      },
+    });
+    await t.mutation(api.functions.mcpServers.createOAuthFlow, {
+      mcpServerId,
+      flowId: "pending-flow",
+      serverUrl: "https://api.githubcopilot.com/mcp/",
+      codeVerifier: "code-verifier",
+      state: "state-2",
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+      authorizationServerUrl: "https://github.com/login/oauth",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    await t.mutation(api.functions.mcpServers.update, {
+      mcpServerId,
+      patch: {
+        oauthStaticClientInfo: {
+          client_id: "new-github-client-id",
+          client_secret: "github-client-secret",
+        },
+      },
+    });
+
+    const [server] = await t.query(api.functions.mcpServers.getByIds, {
+      serverIds: [mcpServerId],
+    });
+    expect(server).toMatchObject({
+      mcpServerId,
+      oauthStaticClientInfo: {
+        client_id: "new-github-client-id",
+        client_secret: "github-client-secret",
+      },
+    });
+    expect(server?.oauthTokens).toBeUndefined();
+    expect(server?.oauthClientInfo).toBeUndefined();
+    expect(server?.oauthServerMetadata).toBeUndefined();
+
+    await expect(
+      t.mutation(api.functions.mcpServers.saveOAuthTokens, {
+        mcpServerId,
+        flowId: "pending-flow",
+        tokens: {
+          access_token: "stale-access-token",
+          token_type: "Bearer",
+        },
+        clientInfo: {
+          client_id: "github-client-id",
+          client_secret: "github-client-secret",
+        },
+        serverMetadata: {
+          authorizationServerUrl: "https://github.com/login/oauth",
+          tokenEndpoint: "https://github.com/login/oauth/access_token",
+        },
+      }),
+    ).rejects.toThrow("OAuth flow expired or not found");
+  });
+
   it("rejects unsafe or duplicate auth headers", async () => {
     const t = authedTest();
 

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -561,6 +561,10 @@ export const update = mutation({
         server.oauthStaticClientInfo,
       );
 
+    if (oauthIdentityChanged) {
+      await deleteOAuthFlowsForServer(ctx, server.mcpServerId);
+    }
+
     await ctx.db.patch(server._id, {
       name: nextName,
       url: nextUrl,
@@ -704,6 +708,22 @@ export const bulkSetToolPermissions = mutation({
 const MAX_OAUTH_FLOWS_PER_USER = 10;
 const OAUTH_FLOW_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
 
+async function deleteOAuthFlowsForServer(
+  ctx: GenericMutationCtx<DataModel> & { userId: string },
+  mcpServerId: string,
+) {
+  const flows = await ctx.db
+    .query("mcpOAuthFlows")
+    .withIndex("by_userId", (q) => q.eq("userId", ctx.userId))
+    .collect();
+
+  await Promise.all(
+    flows
+      .filter((flow) => flow.mcpServerId === mcpServerId)
+      .map(async (flow) => ctx.db.delete(flow._id)),
+  );
+}
+
 export const createOAuthFlow = mutation({
   args: {
     mcpServerId: v.string(),
@@ -810,6 +830,38 @@ export const saveOAuthTokens = mutation({
   },
   handler: async (ctx, args) => {
     const server = await getMcpServerForUser(ctx, args.mcpServerId);
+    const flow = await ctx.db
+      .query("mcpOAuthFlows")
+      .withIndex("by_flowId", (q) => q.eq("flowId", args.flowId))
+      .first();
+
+    if (
+      flow?.userId !== ctx.userId ||
+      flow.mcpServerId !== server.mcpServerId ||
+      Date.now() - flow.createdAt > OAUTH_FLOW_MAX_AGE_MS
+    ) {
+      throw new ConvexError(
+        "OAuth flow expired or not found. Please try connecting again.",
+      );
+    }
+
+    if (flow.serverUrl !== server.url) {
+      throw new ConvexError(
+        "OAuth flow no longer matches this MCP server. Please reconnect.",
+      );
+    }
+
+    if (server.oauthStaticClientInfo) {
+      const staticClientInfo = server.oauthStaticClientInfo;
+      if (
+        flow.clientId !== staticClientInfo.client_id ||
+        flow.clientSecret !== staticClientInfo.client_secret
+      ) {
+        throw new ConvexError(
+          "OAuth flow no longer matches this MCP server. Please reconnect.",
+        );
+      }
+    }
 
     await ctx.db.patch(server._id, {
       oauthTokens: args.tokens,
@@ -819,14 +871,7 @@ export const saveOAuthTokens = mutation({
       updatedAt: Date.now(),
     });
 
-    // Clean up the flow record
-    const flow = await ctx.db
-      .query("mcpOAuthFlows")
-      .withIndex("by_flowId", (q) => q.eq("flowId", args.flowId))
-      .first();
-    if (flow?.userId === ctx.userId) {
-      await ctx.db.delete(flow._id);
-    }
+    await ctx.db.delete(flow._id);
 
     return { mcpServerId: server.mcpServerId };
   },

--- a/packages/backend/convex/functions/mcpServers.ts
+++ b/packages/backend/convex/functions/mcpServers.ts
@@ -12,6 +12,8 @@ import { mutation, query } from "./index";
 const MAX_AUTH_HEADERS = 20;
 const MAX_HEADER_NAME_LENGTH = 128;
 const MAX_HEADER_VALUE_LENGTH = 4096;
+const MAX_OAUTH_CLIENT_ID_LENGTH = 512;
+const MAX_OAUTH_CLIENT_SECRET_LENGTH = 4096;
 const headerNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const mcpServerTransport = v.union(v.literal("http"), v.literal("sse"));
 type McpServerTransport = "http" | "sse";
@@ -24,6 +26,11 @@ const blockedMcpHostnames = new Set([
 interface McpAuthHeaderInput {
   name: string;
   value: string;
+}
+
+interface McpOAuthStaticClientInfoInput {
+  client_id: string;
+  client_secret?: string;
 }
 
 type AuthenticatedCtx = (
@@ -195,6 +202,51 @@ function normalizeMcpAuthHeaders(
   return normalizedHeaders;
 }
 
+function normalizeMcpOAuthStaticClientInfo(
+  clientInfo: McpOAuthStaticClientInfoInput | undefined,
+) {
+  if (!clientInfo) {
+    return undefined;
+  }
+
+  const clientId = clientInfo.client_id.trim();
+  const clientSecret = clientInfo.client_secret?.trim() ?? "";
+
+  if (!clientId && !clientSecret) {
+    return undefined;
+  }
+
+  if (!clientId) {
+    throw new ConvexError(
+      "OAuth client ID is required when a client secret is provided",
+    );
+  }
+
+  if (clientId.length > MAX_OAUTH_CLIENT_ID_LENGTH) {
+    throw new ConvexError("OAuth client ID is too long");
+  }
+
+  if (clientSecret.length > MAX_OAUTH_CLIENT_SECRET_LENGTH) {
+    throw new ConvexError("OAuth client secret is too long");
+  }
+
+  if (/[\r\n]/.test(clientId) || /[\r\n]/.test(clientSecret)) {
+    throw new ConvexError("OAuth client credentials cannot contain new lines");
+  }
+
+  return {
+    client_id: clientId,
+    ...(clientSecret ? { client_secret: clientSecret } : {}),
+  };
+}
+
+function areOAuthStaticClientInfosEqual(
+  a: ReturnType<typeof normalizeMcpOAuthStaticClientInfo>,
+  b: ReturnType<typeof normalizeMcpOAuthStaticClientInfo>,
+) {
+  return a?.client_id === b?.client_id && a?.client_secret === b?.client_secret;
+}
+
 async function getMcpServerForUser(
   ctx: GenericMutationCtx<DataModel> & { userId: string },
   mcpServerId: string,
@@ -316,7 +368,12 @@ async function listConfiguredServers(
     url: server.url,
     transport: normalizeMcpServerTransport(server.transport),
     ...(options.includeAuthHeaders
-      ? { authHeaders: server.authHeaders ?? [] }
+      ? {
+          authHeaders: server.authHeaders ?? [],
+          ...(server.oauthStaticClientInfo
+            ? { oauthStaticClientInfo: server.oauthStaticClientInfo }
+            : {}),
+        }
       : {}),
     toolPermissions: server.toolPermissions ?? {},
     hasOAuth: server.oauthTokens !== undefined,
@@ -395,6 +452,7 @@ export const getByIds = query({
           toolPermissions: server.toolPermissions ?? {},
           oauthTokens: server.oauthTokens,
           oauthClientInfo: server.oauthClientInfo,
+          oauthStaticClientInfo: server.oauthStaticClientInfo,
           oauthServerMetadata: server.oauthServerMetadata,
         };
       }),
@@ -417,11 +475,20 @@ export const create = mutation({
         }),
       ),
     ),
+    oauthStaticClientInfo: v.optional(
+      v.object({
+        client_id: v.string(),
+        client_secret: v.optional(v.string()),
+      }),
+    ),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
     const mcpServerId = crypto.randomUUID();
     const authHeaders = normalizeMcpAuthHeaders(args.authHeaders);
+    const oauthStaticClientInfo = normalizeMcpOAuthStaticClientInfo(
+      args.oauthStaticClientInfo,
+    );
 
     await ctx.db.insert("mcpServers", {
       mcpServerId,
@@ -430,6 +497,7 @@ export const create = mutation({
       url: normalizeMcpServerUrl(args.url),
       transport: normalizeMcpServerTransport(args.transport),
       authHeaders: authHeaders.length > 0 ? authHeaders : undefined,
+      oauthStaticClientInfo,
       createdAt: now,
       updatedAt: now,
     });
@@ -455,6 +523,12 @@ export const update = mutation({
           }),
         ),
       ),
+      oauthStaticClientInfo: v.optional(
+        v.object({
+          client_id: v.string(),
+          client_secret: v.optional(v.string()),
+        }),
+      ),
     }),
   },
   handler: async (ctx, args) => {
@@ -476,12 +550,31 @@ export const update = mutation({
       args.patch.authHeaders !== undefined
         ? normalizeMcpAuthHeaders(args.patch.authHeaders)
         : (server.authHeaders ?? []);
+    const nextOAuthStaticClientInfo =
+      args.patch.oauthStaticClientInfo !== undefined
+        ? normalizeMcpOAuthStaticClientInfo(args.patch.oauthStaticClientInfo)
+        : server.oauthStaticClientInfo;
+    const oauthIdentityChanged =
+      nextUrl !== server.url ||
+      !areOAuthStaticClientInfosEqual(
+        nextOAuthStaticClientInfo,
+        server.oauthStaticClientInfo,
+      );
 
     await ctx.db.patch(server._id, {
       name: nextName,
       url: nextUrl,
       transport: nextTransport,
       authHeaders: nextAuthHeaders.length > 0 ? nextAuthHeaders : undefined,
+      oauthStaticClientInfo: nextOAuthStaticClientInfo,
+      ...(oauthIdentityChanged
+        ? {
+            oauthTokens: undefined,
+            oauthClientInfo: undefined,
+            oauthServerMetadata: undefined,
+            oauthTokensIssuedAt: undefined,
+          }
+        : {}),
       updatedAt: Date.now(),
     });
 
@@ -491,6 +584,9 @@ export const update = mutation({
       url: nextUrl,
       transport: nextTransport,
       authHeaders: nextAuthHeaders,
+      ...(nextOAuthStaticClientInfo
+        ? { oauthStaticClientInfo: nextOAuthStaticClientInfo }
+        : {}),
     };
   },
 });
@@ -770,6 +866,8 @@ export const clearOAuthTokens = mutation({
     await ctx.db.patch(server._id, {
       oauthTokens: undefined,
       oauthClientInfo: undefined,
+      oauthServerMetadata: undefined,
+      oauthTokensIssuedAt: undefined,
       updatedAt: Date.now(),
     });
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -187,6 +187,12 @@ export default defineSchema({
         client_secret: v.optional(v.string()),
       }),
     ),
+    oauthStaticClientInfo: v.optional(
+      v.object({
+        client_id: v.string(),
+        client_secret: v.optional(v.string()),
+      }),
+    ),
     oauthServerMetadata: v.optional(
       v.object({
         authorizationServerUrl: v.string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add optional static OAuth client credentials for MCP servers that do not support dynamic client registration.
- Use saved static client info during MCP OAuth authorization while preserving dynamic registration for compatible servers.
- Expose static OAuth client fields in MCP settings and preserve them when disconnecting OAuth tokens.
- Address review feedback by invalidating pending OAuth flows on identity changes, rejecting stale callback saves, guarding collapsed OAuth connect for dirty drafts, and expanding backend coverage.
- Fix the remaining app lint warning and React Doctor accessibility warning in the changed MCP settings UI.
- Make MCP connection/tool failures user-facing with the MCP server name and recovery guidance in chat failures.
- Apply Prettier formatting to the MCP settings manager.

### Testing
- `pnpm -F @redux/tanstack-start format`
- `pnpm -F @redux/backend exec vitest run convex/functions/mcpServers.test.ts`
- `pnpm -F @redux/tanstack-start typecheck`
- `pnpm -F @redux/backend typecheck`
- `rm -f packages/backend/convex/tsconfig.json && pnpm -F @redux/backend lint`
- `pnpm -F @redux/tanstack-start lint`
- `npx react-doctor@latest --verbose --diff`
- `pnpm -F @redux/tanstack-start exec tsx -e "..."` verified GitHub Copilot MCP metadata fails without static client and returns a GitHub authorization redirect with static client.
- Manual UI walkthrough recorded: [mcp_static_oauth_settings_walkthrough.mp4](https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_static_oauth_settings_walkthrough.mp4)
- Manual Connect with OAuth button click recorded: [mcp_oauth_connect_button_github_login_clean.mp4](https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_oauth_connect_button_github_login_clean.mp4)
- Manual dirty-state OAuth guard recorded: [mcp_dirty_oauth_button_disabled_visible.mp4](https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_dirty_oauth_button_disabled_visible.mp4)
- Manual MCP settings lint-fix sanity check recorded: [mcp_settings_lint_fix_sanity.mp4](https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_settings_lint_fix_sanity.mp4)
- Manual MCP chat error handling check recorded: [mcp_chat_error_specific_message.mp4](https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_chat_error_specific_message.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33a52a05-55e2-441f-826d-60870d8b894b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33a52a05-55e2-441f-826d-60870d8b894b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-MCP-server static OAuth client credentials (Client ID + optional Client Secret) with persistence, normalization, and OAuth flow preloading.
  * Improved OAuth connect/disconnect UX by blocking actions when changes are unsaved (including a visible dirty-state notice).

* **Bug Fixes**
  * Static credential validation now enforces trimming, length limits, paired requirements, and rejects newlines.
  * Updating static OAuth settings invalidates prior OAuth tokens/metadata; clearing tokens keeps saved static credentials.
  * MCP-related errors are now displayed more consistently in the chat UI and runtime error messaging.

* **Tests**
  * Added coverage for create/update/clear behavior, normalization, validation failures, and token invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->