### PR TITLE
Hide TanStack devtools on mobile

### DIFF
--- a/apps/tanstack-start/src/components/devtools/tanstack-devtools.tsx
+++ b/apps/tanstack-start/src/components/devtools/tanstack-devtools.tsx
@@ -4,7 +4,15 @@ import { TanStackDevtools } from "@tanstack/react-devtools";
 import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 
+import { useIsMobile } from "@redux/ui/hooks/use-mobile";
+
 export default function AppTanStackDevtools() {
+  const isMobileViewport = useIsMobile();
+
+  if (isMobileViewport) {
+    return null;
+  }
+
   return (
     <TanStackDevtools
       plugins={[


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Hide TanStack Devtools on mobile viewports so the dev-only overlay cannot intercept the chat composer/send control.

### Walkthrough
[mobile_viewport_chat_send_completes.mp4](https://cursor.com/agents/bc-15f6316f-163d-4c6e-814e-11d491b49f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_viewport_chat_send_completes.mp4)
[Mobile chat send final response](https://cursor.com/agents/bc-15f6316f-163d-4c6e-814e-11d491b49f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_viewport_chat_send_final_response.webp)

### Testing
- `pnpm -F @redux/tanstack-start typecheck`
- `pnpm -F @redux/tanstack-start lint`
- `pnpm -F @redux/tanstack-start format`
- `npx react-doctor@latest --verbose --diff`
- Manual mobile-width chat send at 375px viewport: sent `What is 8 times 7? Reply with only the number.`, received `56`, and loading ended.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f6316f-163d-4c6e-814e-11d491b49f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f6316f-163d-4c6e-814e-11d491b49f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

